### PR TITLE
job: add '--monitor' option

### DIFF
--- a/job
+++ b/job
@@ -125,6 +125,12 @@ def main(args=None):
     if scriptName == 'job' and not options.foreground:
         childPid = os.fork()
         if childPid > 0:
+            if options.monitor:
+                monitor = ["tail", "-n+0", "-f", job.logfile]
+                print("Monitoring with 'tail -f', use Ctrl-C to stop "
+                      "monitoring\n\n")
+                sys.stdout.flush()
+                os.execvp(monitor[0], monitor)
             sys.exit(0)
         os.setsid()
         job.pid = os.getpid()
@@ -496,8 +502,11 @@ def parseArgs(args=None):
         const=1)
     op.add_argument('-q', '--quiet', action='store_true',
                     help='Do not print any messages')
-    op.add_argument("-f", "--foreground", action="store_true",
-                    help="Do not fork, run in foreground.")
+    execMode = op.add_mutually_exclusive_group()
+    execMode.add_argument("-f", "--foreground", action="store_true",
+                          help="Do not fork, run in foreground.")
+    execMode.add_argument("--monitor", action="store_true",
+                          help="Run in the background, but monitor output")
     op.add_argument("-c", "--command", metavar="CMD",
                     help="Specify complete bash command to execute "
                     "(argument to bash -c)")

--- a/jobrunner/db.py
+++ b/jobrunner/db.py
@@ -135,7 +135,10 @@ class Database(object):
 
     def recentGet(self):
         if self.RECENT in self.db:
-            return json.loads(self.db[self.RECENT])
+            try:
+                return json.loads(self.db[self.RECENT])
+            except json.JSONDecodeError:
+                return None
         else:
             return None
 

--- a/jobrunner/test/integration/smoke_test.py
+++ b/jobrunner/test/integration/smoke_test.py
@@ -151,6 +151,7 @@ class RunExecOptionsTest(TestCase):
     Test the following (exec related) options
         --quiet
         --foreground
+        --monitor
         --command
         --retry
         --reminder
@@ -274,6 +275,22 @@ class RunExecOptionsTest(TestCase):
             pprint(out.replace('\r', '\n').splitlines())
             # While it was running...
             self.assertIn('1 job running', out)
+
+    def testMonitor(self):
+        # --monitor
+        with testEnv():
+            print('+ job --monitor -c "echo MARKOUTPUT"')
+            sub = Popen(['job', '--monitor', '-c',
+                         'echo MARKOUTPUT'], stdout=PIPE)
+            out = sub.stdout.read(50)
+            self.assertIn("Monitoring with", out)
+            waitFor(noJobs)
+            sub.terminate()
+            sub.wait()
+            out += sub.stdout.read()
+            pprint(out.replace('\r', '\n').splitlines())
+            self.assertIn("MARKOUTPUT", out)
+            self.assertIn("return code: 0", out)
 
 
 MAIL_CONFIG = """


### PR DESCRIPTION
This will tail the log file instead of exiting after forking.