### PR TITLE
job: Enable caching for default action

### DIFF
--- a/job
+++ b/job
@@ -98,6 +98,7 @@ def main(args=None):
     elif options.wait:
         pass
     else:
+        jobs.setDbCaching(True)
         print(jobs.getLog(key=None, thisWs=options.tw, skipReminders=True))
         sys.exit(0)
 


### PR DESCRIPTION
Running `job` with no command just shows the current logfile, and so
it should also enable DB caching.