### PR TITLE
job: More top-level DB caching

### DIFF
--- a/job
+++ b/job
@@ -53,10 +53,12 @@ def main(args=None):
     depWait = []
 
     jobs.lock()
+    jobs.setDbCaching(True)
     jobs.addDeps(options.blocked_by, options.tw, deps, None)
     jobs.addDeps(options.wait, options.tw, deps, depWait)
     jobs.addDeps(options.blocked_by_success, options.tw, deps, depSuccess)
     jobs.addDeps(options.mail, options.tw, deps, None)
+    jobs.setDbCaching(False)
     jobs.unlock()
 
     doIsolate = options.isolate


### PR DESCRIPTION
When setting dependencies, there might be a lot of DB lookups, so it's best
to enable caching for all of the addDeps calls.