### PR TITLE
info: use pipes.quote to generate cmdString

### DIFF
--- a/jobrunner/info.py
+++ b/jobrunner/info.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 from curses.ascii import isprint
 import errno
 import os
-import re
+import pipes
 import signal
 import time
 
@@ -29,14 +29,8 @@ def getUtcTime(val):
     return val
 
 
-def maybeQuoteCmdArg(cmd):
-    if re.search(r'[ \t"\';]', cmd):
-        return "'" + cmd.replace("'", "'\\''") + "'"
-    return cmd
-
-
 def cmdString(cmd):
-    return " ".join(map(maybeQuoteCmdArg, cmd))
+    return " ".join(map(pipes.quote, cmd))
 
 
 class JobInfo(object):

--- a/jobrunner/test/info_test.py
+++ b/jobrunner/test/info_test.py
@@ -121,3 +121,7 @@ class TestInfoHelpers(unittest.TestCase):
         self.assertEqual(info.cmdString(cmd), "ls -l 'some\tfile'")
         cmd = ['ls', '-l', 'some;file']
         self.assertEqual(info.cmdString(cmd), "ls -l 'some;file'")
+
+    def testCmdStringBang(self):
+        cmd = ['ls', '-l', '!something']
+        self.assertEqual(info.cmdString(cmd), "ls -l '!something'")


### PR DESCRIPTION
Instead of the hand-rolled version, just rely on pipes.quote.  The
hand-rolled version wasn't quoting, for example, `!`, but pipes.quote
also takes care of this case.

Added a test case in info_test.py to verify the bang example.