### PR TITLE
db: make copy before trashing old DB

### DIFF
--- a/jobrunner/test/db_database_test.py
+++ b/jobrunner/test/db_database_test.py
@@ -25,7 +25,7 @@ class BaseMixin(object):
         openDb = args[-1]
         openDb.return_value = self.myDict
         initMock.return_value = None
-        testObj = db.Database(None, None, None)
+        testObj = db.Database(None, None, None, "xxx")
         return testObj
 
 


### PR DESCRIPTION
If the database read fails in some cases the database gets recreated
immediately.  It also happens if the schemaVersion changes.  It's not
super friendly, but at least make a copy of the old DB when this
happens.