### PR TITLE
Skip reminders in active job list

### DIFF
--- a/job
+++ b/job
@@ -276,8 +276,9 @@ def addNonExecOptions(op):
     op.add_argument(
         "-l",
         "--list",
-        action="store_true",
-        help="List active jobs")
+        action="append_const",
+        const=True,
+        help="List active jobs, -ll to include active reminders")
     op.add_argument("--dot", action='store_true',
                     help='Show dependency graph for active jobs')
     op.add_argument("--png", action='store_true',
@@ -347,8 +348,10 @@ def handleNonExecOptions(options, jobs):
     # pylint: disable=too-many-return-statements
     # pylint: disable=too-many-statements
     if options.list:
+        includeReminders = len(options.list) > 1
         jobs.listActive(thisWs=options.tw, pane=options.tp,
-                        useCp=options.since_checkpoint)
+                        useCp=options.since_checkpoint,
+                        includeReminders=includeReminders)
         return True
     elif options.dot or options.png or options.svg:
         dot = jobs.makeDot(

--- a/jobrunner/db.py
+++ b/jobrunner/db.py
@@ -358,17 +358,22 @@ class Jobs(object):
                         'TMUX_PANE', curPane)]
         return jobList
 
-    def listDb(self, db, limit, filterWs=False, filterPane=False, useCp=False):
+    def listDb(self, db, limit, filterWs=False, filterPane=False, useCp=False,
+               includeReminders=False):
         # pylint: disable=too-many-arguments
         jobList = self.filterJobs(db, limit, filterWs, filterPane, useCp)
         hasDeps = False
         for job in jobList:
+            if not includeReminders and job.reminder:
+                continue
             if job.depends:
                 hasDeps = self.walkDepTree(
                     lambda j, d: d == 1, db, job.depends, 1)
         if hasDeps:
             print(utils.SPACER)
         for job in jobList:
+            if not includeReminders and job.reminder:
+                continue
             if self.config.verbose:
                 print(job.detail(self.config.verbose[1:]))
             else:
@@ -440,13 +445,14 @@ class Jobs(object):
     def countInactive(self):
         return len(self.inactive.db) - (len(self.inactive.special) - 1)
 
-    def listActive(self, thisWs, pane, useCp):
+    def listActive(self, thisWs, pane, useCp, includeReminders):
         self.listDb(
             self.active,
             None,
             filterWs=thisWs,
             filterPane=pane,
-            useCp=useCp)
+            useCp=useCp,
+            includeReminders=includeReminders)
 
     def listInactive(self, thisWs, pane, useCp, limit=5):
         self.listDb(

--- a/jobrunner/test/integration/smoke_test.py
+++ b/jobrunner/test/integration/smoke_test.py
@@ -220,10 +220,12 @@ class RunExecOptionsTest(TestCase):
             # --reminder
             # --done
             jobf('--reminder', 'do something')
-            out = jobf('-l')
+            out = jobf('-ll')
             self.assertIn('Reminder: do something', out)
-            jobf('--done', 'something')
             out = jobf('-l')
+            self.assertNotIn('Reminder: do something', out)
+            jobf('--done', 'something')
+            out = jobf('-ll')
             self.assertNotIn('Reminder: do something', out)
 
             # --key


### PR DESCRIPTION
- Only show reminders with `-ll`
- Address integration test failures by skipping `runMeAsRoot`.