### PR TITLE
watch: display only summary for reminders

### DIFF
--- a/jobrunner/config.py
+++ b/jobrunner/config.py
@@ -8,7 +8,17 @@ Sample rcfile:
     [mail]
     program = mail
     domain = example.com
+    [ui]
+    watch reminder = full|summary  # default=summary
 """
+
+WATCH_REMINDER_FULL = "full"
+WATCH_REMINDER_SUMMARY = "summary"
+WATCH_REMINDER_OPTIONS = (
+    WATCH_REMINDER_FULL,
+    WATCH_REMINDER_SUMMARY,
+)
+WATCH_REMINDER_DEFAULT = WATCH_REMINDER_SUMMARY
 
 
 def _getConfig(cfgParser, section, option, defaultValue=None):
@@ -24,8 +34,10 @@ class ConfigError(Exception):
 
 
 class Config(object):
+    # pylint: disable=too-many-instance-attributes
     validConfig = {
         'mail': {'domain', 'program'},
+        'ui': {'watch reminder'},
     }
 
     def _validateConfigParser(self, cfgParser):
@@ -58,6 +70,14 @@ class Config(object):
         self._mailDomain = _getConfig(
             cfgParser, "mail", "domain", os.getenv('HOSTNAME'))
         self._mailProgram = _getConfig(cfgParser, "mail", "program", "mail")
+        self._uiWatchReminder = _getConfig(
+            cfgParser, "ui", "watch reminder", WATCH_REMINDER_DEFAULT)
+        if self._uiWatchReminder not in WATCH_REMINDER_OPTIONS:
+            raise ConfigError(
+                "RC file has invalid \"ui.watch reminder\" setting {}.  Valid "
+                "options: {}".format(self._uiWatchReminder,
+                                     ", ".join(WATCH_REMINDER_OPTIONS)))
+
         self._validateConfigParser(cfgParser)
 
     @property
@@ -90,3 +110,7 @@ class Config(object):
     @property
     def mailProgram(self):
         return self._mailProgram
+
+    @property
+    def uiWatchReminderSummary(self):
+        return self._uiWatchReminder == WATCH_REMINDER_SUMMARY

--- a/jobrunner/db.py
+++ b/jobrunner/db.py
@@ -218,6 +218,29 @@ class Database(object):
         return cur
 
 
+def reminderWatchSummary(activeReminder):
+    if activeReminder:
+        return " (\033[32m{} reminders\033[0m)".format(len(activeReminder))
+    else:
+        return ""
+
+
+def reminderWatchFull(activeReminder):
+    reminders = ""
+    if activeReminder:
+        reminderList = []
+        for remindJob in activeReminder:
+            workspace = ""
+            wsVal = remindJob.wsBasename()
+            if wsVal:
+                workspace = "%s: " % wsVal
+            reminderList.append(
+                '[%s%s]' %
+                (workspace, remindJob.cmdStr))
+        reminders = " " + " ".join(reminderList)
+    return reminders
+
+
 class Jobs(object):
     # pylint: disable=too-many-public-methods
     # pylint: disable=too-many-instance-attributes
@@ -654,22 +677,14 @@ class Jobs(object):
                 else:
                     jobInfo = "%d jobs" % count
 
-                reminders = ""
-                if activeReminder:
-                    reminderList = []
-                    for remindJob in activeReminder:
-                        workspace = ""
-                        wsVal = remindJob.wsBasename()
-                        if wsVal:
-                            workspace = "%s: " % wsVal
-                        reminderList.append(
-                            '[%s%s]' %
-                            (workspace, remindJob.cmdStr))
-                    reminders = " " + " ".join(reminderList)
-
                 if timeNow >= resUpd + resUpdInterval:
                     resUpd = timeNow
                     resource = self.getResources()
+
+                reminderFunc = (
+                    reminderWatchSummary
+                    if self.config.uiWatchReminderSummary else reminderWatchFull)
+                reminders = reminderFunc(activeReminder)
 
                 outStr = (timestr + " " + jobInfo + " running" + reminders +
                           ", " + resource)


### PR DESCRIPTION
Instead of displaying the full list of workspace + reminder text in the
watch mode (`job -W`), make it configurable in a new config `ui`
section.  The sumary mode just prints the reminder count, and the
invdividual reminders can be shown using `job -ll` or `job -a`.