### PR TITLE
db: safer checkpoint handling

### DIFF
--- a/jobrunner/db.py
+++ b/jobrunner/db.py
@@ -109,7 +109,7 @@ class Database(object):
     def getCheckpoint(self):
         try:
             return dateTimeFromJson(json.loads(self.db[self.CHECKPOINT]))
-        except (KeyError, EOFError):
+        except (KeyError, EOFError, json.scanner.JSONDecodeError):
             epoch = datetime.utcfromtimestamp(0)
             return epoch.replace(tzinfo=tzutc())
 

--- a/testenv
+++ b/testenv
@@ -1,9 +1,9 @@
 #!/bin/sh
 function setup() {
     echo "Create virtualenv $VIRTUAL_ENV"
-    if ! test -d ${VENV}; then
+    if ! test -d ${VIRTUAL_ENV}; then
         export _TESTENV_IN_NEWENV=1
-        virtualenv --python=python2.7 ${VENV} || return 1
+        virtualenv --python=python2.7 ${VIRTUAL_ENV} || return 1
     else
         export _TESTENV_IN_NEWENV=0
     fi


### PR DESCRIPTION
In case the db _has_ self.CHECKPOINT, but it returns an empty string,
also catch JSONDecodeError.

Fixed wrong var name in testenv as well.