### PR TITLE
job: use sqlite3 instead of dbm

### DIFF
--- a/job
+++ b/job
@@ -5,8 +5,7 @@ import argparse
 import errno
 import hashlib
 import os
-import subprocess
-from subprocess import PIPE
+from subprocess import PIPE, CalledProcessError, Popen, check_call, check_output
 import sys
 import tempfile
 
@@ -197,8 +196,7 @@ def main(args=None):
             depJob = jobs.inactive[j.permKey]
             safeWrite(tmp, depJob.detail(options.verbose))
             safeWrite(tmp, "\n" + SPACER_EACH + "\n")
-            safeWrite(tmp, subprocess.check_output(['tail', '-n20',
-                                                    depJob.logfile]))
+            safeWrite(tmp, check_output(['tail', '-n20', depJob.logfile]))
             safeWrite(tmp, SPACER_EACH + "\n")
             safeWrite(tmp, "\n")
             try:
@@ -366,7 +364,7 @@ def handleNonExecOptions(options, jobs):
             fName = '~%s/output/job.svg' % os.getenv('USER')
             ofile = os.path.expanduser(fName)
             cmd = ['dot', '-Tsvg', '-o', ofile]
-            proc = subprocess.Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
+            proc = Popen(cmd, stdout=PIPE, stderr=PIPE, stdin=PIPE)
             stdout, stderr = proc.communicate(input=dot)
             if stdout.strip() or stderr.strip():
                 raise ExitCode(stdout + stderr)
@@ -405,11 +403,11 @@ def handleNonExecOptions(options, jobs):
             print("==============================================")
             print(j)
             try:
-                print(subprocess.check_output(['pstree', '-alpg', str(j.pid)]))
+                print(check_output(['pstree', '-alpg', str(j.pid)]))
             except OSError as error:
                 if error.errno != errno.ENOENT:
                     raise
-                print(subprocess.check_output(['ps', '-fp', str(j.pid)]))
+                print(check_output(['ps', '-fp', str(j.pid)]))
             print("==============================================")
         return True
     elif options.last_key:
@@ -674,14 +672,14 @@ def runJob(cmd, options, jobs, job, fp, doIsolate):
             print('Isolating command IS :', netnsd)
         cmd = netnsd
     try:
-        rc = subprocess.check_call(cmd, stdin=fpIn, stdout=fp, stderr=fp)
+        rc = check_call(cmd, stdin=fpIn, stdout=fp, stderr=fp)
     except KeyboardInterrupt:
         print("\ninterrupted")
         rc = -1
     except OSError as err:
         rc = -1 * err.errno
         print(err, file=open(job.logfile, 'a'))
-    except subprocess.CalledProcessError as err:
+    except CalledProcessError as err:
         rc = err.returncode
     except Exception:
         rc = -1

--- a/job
+++ b/job
@@ -13,8 +13,9 @@ import dateutil.parser
 import dateutil.tz
 
 from jobrunner.config import RC_FILE_HELP, Config
-from jobrunner.db import Jobs
 from jobrunner.plugins import Plugins
+from jobrunner.service import service
+from jobrunner.service.registry import registerServices
 from jobrunner.utils import (
     DATETIME_FMT,
     MOD_STATE,
@@ -39,11 +40,14 @@ def main(args=None):
     plugins = Plugins()
     MOD_STATE.plugins = plugins
 
+    registerServices(sqlite=bool("USE_DBM" not in os.environ))
+
     options = parseArgs(args)
     config = Config(options)
-    jobs = Jobs(config, plugins)
+    jobs = service().db.jobs(config, plugins)
 
     maybeStartDebugger(options)
+    jobs.lock()
     maybeHandleNonExecOptions(options, jobs)
     maybeHandleNonExecWriteOptions(options, jobs)
 
@@ -51,19 +55,13 @@ def main(args=None):
     deps = []
     depSuccess = []
     depWait = []
-
-    jobs.lock()
-    jobs.setDbCaching(True)
     jobs.addDeps(options.blocked_by, options.tw, deps, None)
     jobs.addDeps(options.wait, options.tw, deps, depWait)
     jobs.addDeps(options.blocked_by_success, options.tw, deps, depSuccess)
     jobs.addDeps(options.mail, options.tw, deps, None)
-    jobs.setDbCaching(False)
-    jobs.unlock()
 
     doIsolate = options.isolate
     cmd = []
-    jobs.setDbCaching(True)
     if options.mail:
         oneJob = jobs.getJobMatch(options.mail[0], options.tw)
         subj = '[job-status] '
@@ -102,32 +100,22 @@ def main(args=None):
         pass
     else:
         print(jobs.getLog(key=None, thisWs=options.tw, skipReminders=True))
+        jobs.unlock()
         sys.exit(0)
-    jobs.setDbCaching(False)
 
     if depWait:
-        while depWait:
-            dep = depWait.pop(0)
-            k = dep.permKey
-            jobs.waitFor(dep, options.verbose)
-            jobs.waitInactive(k, options.verbose)
-            j = jobs.inactive[k]
-            if j.rc != 0:
-                print("\nDependent job failed: %s" % j)
-                print("key: %s" % j.key)
-                print("return code: %d" % j.rc)
-                sys.exit(j.rc)
-        sys.exit(0)
+        rc = waitForDep(depWait, options, jobs)
+        jobs.unlock()
+        sys.exit(rc)
 
-    jobs.lock()
     job, fp = jobs.new(cmd, doIsolate, autoJob=options.auto_job,
                        key=options.key, reminder=options.reminder)
     job.genPersistKey(jobs.inactive)
     jobs.active[job.key] = job
-    jobs.unlock()
 
     scriptName = os.path.basename(sys.argv[0])
     if scriptName == 'job' and not options.foreground:
+        jobs.unlock()
         childPid = os.fork()
         if childPid > 0:
             if options.monitor:
@@ -141,7 +129,6 @@ def main(args=None):
         job.pid = os.getpid()
         jobs.lock()
         jobs.active[job.key] = job
-        jobs.unlock()
 
     if options.mail:
         job.mailJob = True
@@ -164,6 +151,7 @@ def main(args=None):
             job.setDependencies(jobs, None)
     if aborted:
         job.stop(jobs, STOP_ABORT)
+        jobs.unlock()
         sys.exit(-1)
 
     for oldJob in depSuccess:
@@ -177,11 +165,13 @@ def main(args=None):
             print("\nDependent job failed: %s" % j)
             print("key: %s" % job.key)
             print("return code: %d" % j.rc)
+            jobs.unlock()
             sys.exit(j.rc)
 
     job.start(jobs)
     if cmd is None and options.reminder is not None:
         print("reminder: '%s'" % options.reminder)
+        jobs.unlock()
         sys.exit(0)
 
     if options.mail:
@@ -210,6 +200,21 @@ def main(args=None):
         cmd.append(lastArg)
 
     runJob(cmd, options, jobs, job, fp, doIsolate)
+
+
+def waitForDep(depWait, options, jobs):
+    while depWait:
+        dep = depWait.pop(0)
+        k = dep.permKey
+        jobs.waitFor(dep, options.verbose)
+        jobs.waitInactive(k, options.verbose)
+        j = jobs.inactive[k]
+        if j.rc != 0:
+            print("\nDependent job failed: %s" % j)
+            print("key: %s" % j.key)
+            print("return code: %d" % j.rc)
+            return j.rc
+    return 0
 
 
 def safeWrite(fp, value):
@@ -398,17 +403,11 @@ def handleNonExecOptions(options, jobs):
             print(j.detail(options.verbose))
         return True
     elif options.pid:
-        for k in options.pid:
-            j = jobs.getJobMatch(k, options.tw)
-            print("==============================================")
-            print(j)
+        for key in options.pid:
             try:
-                print(check_output(['pstree', '-alpg', str(j.pid)]))
-            except OSError as error:
-                if error.errno != errno.ENOENT:
-                    raise
-                print(check_output(['ps', '-fp', str(j.pid)]))
-            print("==============================================")
+                showPstreeForKey(key, jobs, options)
+            except KeyError as error:
+                print("Error:", error.message)
         return True
     elif options.last_key:
         print(jobs.inactive.lastKey)
@@ -418,6 +417,7 @@ def handleNonExecOptions(options, jobs):
         for index in options.index:
             logs.append(jobs.getLogByIndex(index, options.tw))
         print(" ".join(logs))
+        jobs.unlock()
         sys.exit(0)
     elif options.info:
         print(jobs.active)
@@ -452,7 +452,7 @@ def handleNonExecWriteOptions(options, jobs):
         done = False
         for k in options.int:
             j = jobs.getJobMatch(k, options.tw)
-            j.killPgrp()
+            j.killPgrp(jobs)
             done = True
         if not done:
             raise ExitCode(1)
@@ -494,6 +494,61 @@ def handleNonExecWriteOptions(options, jobs):
         return True
     else:
         return False
+
+
+def pidOk(pid):
+    if not pid:
+        return False
+    try:
+        os.kill(pid, 0)
+    except OSError as error:
+        if error.errno == errno.EPERM:
+            # Operation not permitted
+            return True
+        elif error.errno == errno.ESRCH:
+            # No such process
+            return False
+        else:
+            raise
+    return True
+
+
+class Pstree(object):
+    def __init__(self, text):
+        self.text = text.strip() if text else None
+        self.errors = []
+
+
+def getPstree(pid):
+    pstree = Pstree(None)
+    try:
+        return Pstree(check_output(['pstree', '-alpg', str(pid)]))
+    except (OSError, CalledProcessError) as error:
+        pstree.errors.append(error)
+    try:
+        return Pstree(check_output(['ps', '-fp', str(pid)]))
+    except (OSError, CalledProcessError) as error:
+        pstree.errors.append(error)
+    return pstree
+
+
+def showPstreeForKey(key, jobs, options):
+    j = jobs.getJobMatch(key, options.tw)
+    print("==============================================")
+    print(j)
+    if pidOk(j.pid):
+        pstree = getPstree(j.pid)
+        if not pstree.errors:
+            print(pstree.text)
+        elif pidOk(j.pid):
+            print("Errors getting PID info for", j.pid)
+            for err in pstree.errors:
+                print(err)
+        else:
+            print("PID not found", j.pid)
+    else:
+        print("PID not found", j.pid)
+    print("==============================================")
 
 
 def parseArgs(args=None):
@@ -637,15 +692,15 @@ def maybeHandle(options, jobs, handler):
     try:
         handled = handler(options, jobs)
         if handled:
+            jobs.unlock()
             sys.exit(0)
     except ExitCode as exitCode:
+        jobs.unlock()
         sys.exit(exitCode.rc)
 
 
 def maybeHandleNonExecOptions(options, jobs):
-    jobs.setDbCaching(True)
     maybeHandle(options, jobs, handleNonExecOptions)
-    jobs.setDbCaching(False)
 
 
 def maybeHandleNonExecWriteOptions(options, jobs):
@@ -654,6 +709,7 @@ def maybeHandleNonExecWriteOptions(options, jobs):
 
 def runJob(cmd, options, jobs, job, fp, doIsolate):
     # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-statements
     doMsg("execute:", job.cmdStr)
     robotInfo("execute", {"key": job.key}, {"command": job.cmdStr})
     fpIn = open(options.input, "r")
@@ -672,6 +728,7 @@ def runJob(cmd, options, jobs, job, fp, doIsolate):
             print('Isolating command IS :', netnsd)
         cmd = netnsd
     try:
+        jobs.unlock()
         rc = check_call(cmd, stdin=fpIn, stdout=fp, stderr=fp)
     except KeyboardInterrupt:
         print("\ninterrupted")
@@ -685,9 +742,11 @@ def runJob(cmd, options, jobs, job, fp, doIsolate):
         rc = -1
         raise
     finally:
+        jobs.lock()
         job.stop(jobs, rc)
         os.fsync(fp)
         finish(job, rc)
+        jobs.unlock()
     sys.exit(rc)
 
 

--- a/jobrunner/db/dbm_db.py
+++ b/jobrunner/db/dbm_db.py
@@ -1,0 +1,91 @@
+from __future__ import absolute_import, division, print_function
+
+import anydbm
+import errno
+import os
+import shutil
+import time
+
+from . import DatabaseBase, JobsBase, resolveDbFile
+
+
+class DbmDatabase(DatabaseBase):
+    schemaVersion = "4"
+
+    def __init__(self, parent, config, dbFile, instanceId, cached=False):
+        # pylint: disable=too-many-arguments
+        super(DbmDatabase, self).__init__(parent, config, instanceId)
+        self.ident = dbFile
+        self.dbFile = resolveDbFile(config, dbFile)
+        self._dbCache = None
+        self._cached = cached
+        self._instanceId = instanceId
+
+    def _openDb(self):
+        if self._dbCache:
+            return self._dbCache
+        mode = 'r' if self._cached else 'c'
+        db = anydbm.open(self.dbFile, mode)
+        if (self.SV not in db or
+                db[self.SV] != self.schemaVersion):
+            db.close()
+            if os.path.exists(self.dbFile):
+                backup = self.dbFile + '.' + self._instanceId
+                shutil.copy(self.dbFile, backup)
+            db = anydbm.open(self.dbFile, 'n')
+            db[self.SV] = self.schemaVersion
+            db[self.LASTKEY] = ""
+            db[self.LASTJOB] = ""
+            db[self.ITEMCOUNT] = "0"
+            db[self.CHECKPOINT] = ""
+            db.close()
+            db = anydbm.open(self.dbFile, mode)
+        if self._cached:
+            self._dbCache = db
+        return db
+
+    @property
+    def db(self):
+        for _ in range(5):
+            try:
+                return self._openDb()
+            except anydbm.error as error:  # pylint: disable=catching-non-exception
+                errNum = error.args[0]
+                if errNum != errno.EAGAIN:
+                    raise
+                time.sleep(0.25)
+
+
+class DbmJobs(JobsBase):
+    def __init__(self, config, plugins):
+        super(DbmJobs, self).__init__(config, plugins)
+        self.active = DbmDatabase(
+            self, config, 'activeJobs', self._instanceId)
+        self.inactive = DbmDatabase(
+            self, config, 'inactiveJobs', self._instanceId)
+        self._cached = False
+
+    def setDbCaching(self, enabled):
+        if self._cached == enabled:
+            return
+        self._cached = enabled
+        self.active = DbmDatabase(
+            self,
+            self.config,
+            'activeJobs',
+            self._instanceId,
+            cached=enabled)
+        self.inactive = DbmDatabase(
+            self, self.config, 'inactiveJobs', self._instanceId, cached=enabled)
+
+    def isLocked(self):
+        return self._lock.isLocked()
+
+    def lock(self):
+        super(DbmJobs, self).lock()
+        self._lock.lock()
+        self.debugPrint("<< LOCKED")
+
+    def unlock(self):
+        super(DbmJobs, self).unlock()
+        self._lock.unlock()

--- a/jobrunner/db/sqlite_db.py
+++ b/jobrunner/db/sqlite_db.py
@@ -1,0 +1,204 @@
+from __future__ import absolute_import, division, print_function
+
+import sqlite3
+
+from . import DatabaseBase, DatabaseMeta, JobsBase, resolveDbFile
+
+
+class Sqlite3KeyValueStore(DatabaseMeta):
+    def __init__(self, table, schemaVersion):
+        self._schemaVersion = schemaVersion
+        self._schemaOk = False
+        self._dirty = 0
+        self.conn = None
+        self._table = table
+        self._locked = False
+
+    def keys(self):
+        cursor = self._doQuery("SELECT key FROM " + self._table)
+        return [r[0] for r in cursor.fetchall()]
+
+    def __len__(self):
+        query = "SELECT COUNT(key) FROM " + self._table
+        cursor = self._doQuery(query)
+        return int(cursor.fetchone()[0])
+
+    @property
+    def dirty(self):
+        return self._dirty
+
+    def _setDirty(self, _key):
+        assert self._locked
+        self._dirty += 1
+
+    def lock(self):
+        assert not self._locked
+        self._locked = True
+
+    def unlock(self):
+        assert self._locked
+        self._locked = False
+
+    def __setitem__(self, key, value):
+        self._doQuery(
+            "INSERT OR REPLACE INTO " + self._table + " VALUES (?, ?)", key, value)
+        self._setDirty(key)
+
+    def __getitem__(self, key):
+        cursor = self._doQuery(
+            "SELECT value FROM " +
+            self._table +
+            " WHERE key=?",
+            key)
+        row = cursor.fetchone()
+        if not row:
+            raise KeyError(key)
+        return row[0]
+
+    def __delitem__(self, key):
+        self._doQuery("DELETE FROM " + self._table + " WHERE key=?", key)
+        self._setDirty(key)
+
+    def __contains__(self, key):
+        cursor = self._doQuery(
+            "SELECT value FROM " +
+            self._table +
+            " WHERE key=?",
+            key)
+        row = cursor.fetchone()
+        return row is not None
+
+    def _cursor(self):
+        return self.conn.cursor()
+
+    def _doQuery(self, query, *args):
+        assert self._schemaOk
+        cursor = self._cursor()
+        cursor.execute(query, args or [])
+        return cursor
+
+    def _getMeta(self, cursor, key):
+        cursor = cursor.execute(
+            "SELECT value FROM " + self._table + " WHERE key = ?", (key,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+
+    def _createNew(self, cursor):
+        cursor.execute("DROP TABLE IF EXISTS " + self._table)
+        cursor.execute("""
+        CREATE TABLE {} (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        )
+        """.format(self._table))
+        initItems = (
+            (self.SV, self._schemaVersion),
+            (self.LASTKEY, ""),
+            (self.LASTJOB, ""),
+            (self.ITEMCOUNT, "0"),
+            (self.CHECKPOINT, ""),
+        )
+        for key, value in initItems:
+            cursor.execute("INSERT INTO " + self._table + " VALUES (?, ?)",
+                           (key, value))
+        cursor.connection.commit()
+
+    def setup(self, conn):
+        cursor = conn.cursor()
+        cursor.execute(
+            "SELECT * FROM sqlite_master WHERE type='table' AND name=?",
+            (self._table,))
+        tables = cursor.fetchall()
+        if not tables:
+            self._createNew(cursor)
+        dbVer = self._getMeta(cursor, self.SV)
+        if dbVer != self._schemaVersion:
+            self._createNew(cursor)
+        self._schemaOk = True
+
+
+class Sqlite3Database(DatabaseBase):
+    schemaVersion = "0"
+
+    def __init__(self, parent, config, instanceId, name):
+        # pylint: disable=too-many-arguments
+        super(Sqlite3Database, self).__init__(parent, config, instanceId)
+        self._db = Sqlite3KeyValueStore(name, self.schemaVersion)
+        self.ident = name + "Jobs"
+
+    @property
+    def db(self):
+        return self._db
+
+    @property
+    def conn(self):
+        return self._db.conn
+
+    @conn.setter
+    def conn(self, conn):
+        self._db.conn = conn
+
+    @property
+    def dirty(self):
+        return self._db.dirty
+
+    def lock(self):
+        self._db.lock()
+
+    def unlock(self):
+        self._db.unlock()
+
+    def __getattr__(self, attr):
+        return getattr(self._db, attr)
+
+
+def connectDb(filename):
+    conn = sqlite3.connect(filename)
+    conn.isolation_level = 'EXCLUSIVE'
+    return conn
+
+
+class Sqlite3Jobs(JobsBase):
+    def __init__(self, config, plugins):
+        super(Sqlite3Jobs, self).__init__(config, plugins)
+        self._filename = resolveDbFile(config, 'jobsDb.sqlite')
+        self._dbc = None
+        self._lock.lock()
+        conn = connectDb(self._filename)
+        self.active = Sqlite3Database(self, config, self._instanceId, 'active')
+        self.active.setup(conn)
+        self.inactive = Sqlite3Database(
+            self, config, self._instanceId, 'inactive')
+        self.inactive.setup(conn)
+        self._lock.unlock()
+
+    def __del__(self):
+        if self.active.dirty or self.inactive.dirty:
+            self._dbc.commit()
+        self._dbc.close()
+        self._dbc = None
+
+    def isLocked(self):
+        return self._lock.isLocked()
+
+    def lock(self):
+        super(Sqlite3Jobs, self).lock()
+        self._lock.lock()
+        conn = connectDb(self._filename)
+        self.active.conn = conn
+        self.inactive.conn = conn
+        self.active.lock()
+        self.inactive.lock()
+        conn.execute("begin")
+
+    def unlock(self):
+        super(Sqlite3Jobs, self).unlock()
+        conn = self.active.conn
+        if self.active.dirty or self.inactive.dirty:
+            conn.commit()
+        self.active.unlock()
+        self.inactive.unlock()
+        self.active.conn = None
+        self.inactive.conn = None
+        conn.close()
+        self._lock.unlock()

--- a/jobrunner/service/__init__.py
+++ b/jobrunner/service/__init__.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import, division, print_function
+
+
+class _Registry(object):
+    def __init__(self):
+        self._services = {}
+
+    def register(self, identifier, obj):
+        if '.' not in identifier:
+            assert (identifier not in self._services
+                    or self._services[identifier] == obj)
+            self._services[identifier] = obj
+        else:
+            scope, key = identifier.split('.', 1)
+            if scope not in self._services:
+                self._services[scope] = _Registry()
+            self._services[scope].register(key, obj)
+
+    def clear(self, thisIsATest=False):
+        assert thisIsATest
+        self._services.clear()
+
+    def __getattr__(self, key):
+        if key not in self._services:
+            raise AttributeError
+        return self._services[key]
+
+
+__REGISTRY = _Registry()
+
+
+def service():
+    return __REGISTRY

--- a/jobrunner/service/registry.py
+++ b/jobrunner/service/registry.py
@@ -1,0 +1,10 @@
+from . import service
+from ..db.dbm_db import DbmJobs
+from ..db.sqlite_db import Sqlite3Jobs
+
+
+def registerServices(sqlite=False):
+    if sqlite:
+        service().register("db.jobs", Sqlite3Jobs)
+    else:
+        service().register("db.jobs", DbmJobs)

--- a/jobrunner/test/db_database_test.py
+++ b/jobrunner/test/db_database_test.py
@@ -6,7 +6,7 @@ import unittest
 from dateutil.tz import tzlocal, tzutc
 from mock import patch
 
-from jobrunner import db
+from jobrunner.db.dbm_db import DbmDatabase
 
 from .helpers import resetEnv
 
@@ -25,12 +25,12 @@ class BaseMixin(object):
         openDb = args[-1]
         openDb.return_value = self.myDict
         initMock.return_value = None
-        testObj = db.Database(None, None, None, "xxx")
+        testObj = DbmDatabase(None, None, None, "xxx")
         return testObj
 
 
-@patch("jobrunner.db.Database._openDb")
-@patch("jobrunner.db.Database.__init__")
+@patch("jobrunner.db.dbm_db.DbmDatabase._openDb")
+@patch("jobrunner.db.dbm_db.DbmDatabase.__init__")
 @patch("jobrunner.db.utcNow")
 class DatabasePropertiesCheckpointTest(BaseMixin, unittest.TestCase):
     def testCheckpointUnset(self, *args):

--- a/jobrunner/test/db_sqlite_test.py
+++ b/jobrunner/test/db_sqlite_test.py
@@ -1,0 +1,80 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+from tempfile import NamedTemporaryFile
+import unittest
+
+from jobrunner.db.sqlite_db import Sqlite3KeyValueStore, connectDb
+
+
+class KeyValueStoreTest(unittest.TestCase):
+    cached = False
+
+    def store(self, filename=":memory:", ver="0"):
+        self.removeStore()
+        conn = connectDb(filename)
+        store = Sqlite3KeyValueStore("myTable", ver)
+        store.setup(conn)
+        store.conn = conn
+        store.lock()
+        self._store = store
+        return store
+
+    def removeStore(self):
+        if self._store:
+            self._store.conn.commit()
+            self._store.unlock()
+            self._store = None
+        return None
+
+    def setUp(self):
+        self._store = None
+
+    def tearDown(self):
+        if self._store:
+            self._store.unlock()
+            self._store = None
+
+    def testKeys(self):
+        store = self.store()
+        self.assertItemsEqual(store.initvals, store.keys())
+        store['foo'] = 'value'
+        self.assertItemsEqual(list(store.initvals) + ['foo'], store.keys())
+
+    def testLen(self):
+        store = self.store()
+        store['foo'] = 'value'
+        self.assertEqual(len(store.initvals) + 1, len(store))
+
+    def testBasic(self):
+        store = self.store()
+        self.assertNotIn('foo', store)
+        with self.assertRaises(KeyError):
+            _ = store['foo']
+        store['foo'] = '0'
+        self.assertEqual('0', store['foo'])
+        store['foo'] = '1'
+        self.assertEqual('1', store['foo'])
+        self.assertIn('foo', store)
+        del store['foo']
+        self.assertNotIn('foo', store)
+
+    def testWrongVersion(self):
+        with NamedTemporaryFile(delete=False) as tempf:
+            tempf.close()
+        fname = tempf.name
+        store = self.store(fname)
+        store['foo'] = 'bar'
+        store['hello'] = 'goodbye'
+        store = self.removeStore()
+        store = self.store(fname)
+        self.assertEqual('bar', store['foo'])
+        self.assertEqual('goodbye', store['hello'])
+        del store['hello']
+        store = self.removeStore()
+        store = self.store(fname)
+        self.assertNotIn("hello", store)
+        store = self.removeStore()
+        store = self.store(fname, "1")
+        self.assertNotIn("foo", store)
+        os.unlink(fname)

--- a/jobrunner/test/info_test.py
+++ b/jobrunner/test/info_test.py
@@ -28,9 +28,9 @@ def newJob(uidx, cmd, workspaceIdentity="WS"):
     mockPlug = mock.MagicMock(plugins.Plugins)
     mockPlug.workspaceIdentity.return_value = workspaceIdentity
     utils.MOD_STATE.plugins = mockPlug
-    parent = mock.MagicMock(db.Jobs)
-    parent.inactive = mock.MagicMock(db.Database)
-    parent.active = mock.MagicMock(db.Database)
+    parent = mock.MagicMock(db.JobsBase)
+    parent.inactive = mock.MagicMock(db.DatabaseBase)
+    parent.active = mock.MagicMock(db.DatabaseBase)
     jobInfo = info.JobInfo(uidx)
     jobInfo.isolate = False
     jobInfo.setCmd(cmd)

--- a/jobrunner/test/integration/integration_lib.py
+++ b/jobrunner/test/integration/integration_lib.py
@@ -2,11 +2,14 @@ from __future__ import absolute_import, division, print_function
 
 from contextlib import contextmanager
 import os
+from pipes import quote
 import re
 from shutil import rmtree
 from subprocess import STDOUT, CalledProcessError, check_call, check_output
 from tempfile import mkdtemp
 import time
+
+import pexpect
 
 from ..helpers import resetEnv
 
@@ -60,7 +63,7 @@ def testEnv():
 
 
 def run(cmd, capture=False):
-    print('+', ' '.join(cmd))
+    print(' '.join(map(quote, cmd)))
     try:
         if capture:
             return check_output(cmd, stderr=STDOUT)
@@ -134,3 +137,9 @@ def lastKey():
 
 def inactiveCount():
     return int(run(['job', '--count'], capture=True))
+
+
+def spawn(cmd):
+    print(" ".join(map(quote, cmd)))
+    child = pexpect.spawn(cmd[0], cmd[1:], echo=True)
+    return child

--- a/jobrunner/test/service_test.py
+++ b/jobrunner/test/service_test.py
@@ -1,0 +1,62 @@
+from __future__ import absolute_import, division, print_function
+
+import unittest
+
+from jobrunner.service import service
+
+
+class SvcBase(object):
+    @staticmethod
+    def new():
+        raise NotImplementedError
+
+    def api(self, arg):
+        raise NotImplementedError
+
+
+class Svc1(SvcBase):
+    @staticmethod
+    def new():
+        return Svc1()
+
+    def api(self, arg):
+        return 'service1:{}'.format(arg)
+
+
+class Svc2(SvcBase):
+    @staticmethod
+    def new():
+        return Svc2()
+
+    def api(self, arg):
+        return 'service2:{}'.format(arg)
+
+
+class ServiceTest(unittest.TestCase):
+    def setUp(self):
+        service().clear(thisIsATest=True)
+
+    def testSingle(self):
+        service().register('service', Svc1)
+        svc = service().service.new()
+        self.assertEqual('service1:foo', svc.api('foo'))
+        self.assertEqual('service1:bar', svc.api('bar'))
+
+    def testReRegister(self):
+        service().register('service', Svc1)
+        svc = service().service.new()
+        self.assertEqual('service1:foo', svc.api('foo'))
+
+    def testRegisterTwice(self):
+        service().register('service', Svc1)
+        service().register('service', Svc1)
+        with self.assertRaises(AssertionError):
+            service().register('service', Svc2)
+
+    def testMultiple(self):
+        service().register('s1', Svc1)
+        service().register('s2', Svc2)
+        svc1 = service().s1.new()
+        svc2 = service().s2.new()
+        self.assertEqual('service1:foo', svc1.api('foo'))
+        self.assertEqual('service2:foo', svc2.api('foo'))

--- a/requirements.testing.in
+++ b/requirements.testing.in
@@ -2,6 +2,7 @@ autopep8
 isort
 mock
 nose
+pexpect
 pylint
 pytest
 tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,9 @@ more-itertools==5.0.0     # via pytest
 nose==1.3.7
 packaging==19.1           # via pytest, tox
 pathlib2==2.3.4           # via importlib-metadata, pytest
+pexpect==4.8.0
 pluggy==0.12.0            # via pytest, tox
+ptyprocess==0.6.0         # via pexpect
 py==1.8.0                 # via pytest, tox
 pycodestyle==2.5.0        # via autopep8
 pylint==1.9.5

--- a/testenv
+++ b/testenv
@@ -9,11 +9,12 @@ function setup() {
     fi
 }
 VIRTUAL_ENV=${VIRTUAL_ENV:-venv}
+echo Using $VIRTUAL_ENV
 if setup; then
     . ${VIRTUAL_ENV}/bin/activate
     export JOBRUNNER_STATE_DIR=${PWD}/cfg/
     if [[ $_TESTENV_IN_NEWENV -eq 1 ]]; then
-        pip install --upgrade pip
+        pip install --upgrade pip "setuptools<45"
         pip install --upgrade tox pdbpp ipython
         pip install -r requirements.txt
         python setup.py develop


### PR DESCRIPTION
- Major refactoring to use sqlite3 instead of dbm.  Also a lot of DB locking needed to be cleaned up.
- Use `pexpect` for more reliable integration tests, in some instances.
- Use a service API for the DB provider.