### PR TITLE
db: Do not use sentinel value in inactive db

### DIFF
--- a/job
+++ b/job
@@ -110,7 +110,7 @@ def main(args=None):
 
     job, fp = jobs.new(cmd, doIsolate, autoJob=options.auto_job,
                        key=options.key, reminder=options.reminder)
-    job.genPersistKey(jobs.inactive)
+    job.genPersistKey()
     jobs.active[job.key] = job
 
     scriptName = os.path.basename(sys.argv[0])

--- a/jobrunner/db/__init__.py
+++ b/jobrunner/db/__init__.py
@@ -15,6 +15,7 @@ import simplejson as json
 import jobrunner.utils as utils
 
 from ..info import JobInfo, decodeJobInfo, encodeJobInfo
+from ..service import service
 from ..utils import (
     FileLock,
     dateTimeFromJson,
@@ -763,7 +764,7 @@ class JobsBase(object):
         # pylint: disable=too-many-arguments
         if key and key in self.active.db:
             raise Exception("Active key conflict for key '%s'" % key)
-        job = JobInfo(self.uidx(), key)
+        job = service().db.jobInfo(self.uidx(), key)
         job.isolate = isolate
         job.setCmd(cmd, reminder)
         job.pid = os.getpid()

--- a/jobrunner/db/__init__.py
+++ b/jobrunner/db/__init__.py
@@ -45,6 +45,13 @@ class DatabaseMeta(object):
     initvals = frozenset([SV, LASTKEY, LASTJOB, ITEMCOUNT, CHECKPOINT])
     special = frozenset(list(initvals) + [RECENT, IDX])
 
+    def defaultValueGenerator(self, schemaVersion):
+        yield self.SV, schemaVersion
+        yield self.LASTKEY, ""
+        yield self.LASTJOB, ""
+        yield self.ITEMCOUNT, "0"
+        yield self.CHECKPOINT, ""
+
 
 def resolveDbFile(config, filename):
     return os.path.join(config.dbDir, filename)
@@ -251,25 +258,19 @@ class JobsBase(object):
     def prune(self, exceptNum=None):
         allJobs = []
         db = self.inactive
-        for k in db.keys():
-            j = db[k]
-            if isinstance(j, str):
-                del db[k]
-            elif j.key != k:
-                print("Warning, key mismatch k=%s job key=%s" % (repr(k),
-                                                                 repr(j.key)))
-                print(j.detail("vvv"))
-                del db[k]
-            else:
-                allJobs.append(j)
+        for jobKey in db.keys():
+            job = db[jobKey]
+            assert job.key == jobKey, 'job key mismatch "{}" for job {}'.format(
+                jobKey, job)
+            allJobs.append(job)
         allJobs.sort()
         limit = PRUNE_NUM if exceptNum is None else exceptNum
         if len(allJobs) > limit:
-            for j in allJobs[: -1 * limit]:
+            for job in allJobs[: -1 * limit]:
                 if self.config.verbose:
-                    print("Prune '%s'" % j.key)
-                j.removeLog(self.config.verbose)
-                del self.inactive[j.key]
+                    print("Prune '%s'" % job.key)
+                job.removeLog(self.config.verbose)
+                del self.inactive[job.key]
 
     @staticmethod
     def getDbSorted(db, _limit, useCp=False, filterWs=False):
@@ -283,8 +284,6 @@ class JobsBase(object):
                 try:
                     job = db[k]
                 except KeyError:
-                    continue
-                if job in ['Not a valid entry', 'None']:
                     continue
                 if useCp:
                     refTime = job.createTime
@@ -674,8 +673,6 @@ class JobsBase(object):
             remind.setdefault(j.workspace, []).append(j)
         for k in self.inactive.keys():
             j = self.inactive[k]
-            if j in ['Not a valid entry', 'None']:
-                continue
             if not j.stopTime or j.autoJob:
                 continue
             if j.rc in utils.SPECIAL_STATUS:

--- a/jobrunner/db/sqlite_db.py
+++ b/jobrunner/db/sqlite_db.py
@@ -91,14 +91,7 @@ class Sqlite3KeyValueStore(DatabaseMeta):
             value TEXT
         )
         """.format(self._table))
-        initItems = (
-            (self.SV, self._schemaVersion),
-            (self.LASTKEY, ""),
-            (self.LASTJOB, ""),
-            (self.ITEMCOUNT, "0"),
-            (self.CHECKPOINT, ""),
-        )
-        for key, value in initItems:
+        for key, value in self.defaultValueGenerator(self._schemaVersion):
             cursor.execute("INSERT INTO " + self._table + " VALUES (?, ?)",
                            (key, value))
         cursor.connection.commit()

--- a/jobrunner/info.py
+++ b/jobrunner/info.py
@@ -234,13 +234,11 @@ class JobInfo(object):
     def permKey(self):
         return self._persistKeyGenerated
 
-    def genPersistKey(self, inactive):
+    def genPersistKey(self):
         if self._persistKeyGenerated is not None:
             return
         assert self._key
         persistKey = self._key
-        if persistKey not in inactive.db:
-            inactive[persistKey] = 'Not a valid entry'
         self._persistKeyGenerated = persistKey
         return
 
@@ -299,26 +297,26 @@ class JobInfo(object):
     @locked
     def setDependencies(self, parent, onWhat):
         self.depends = onWhat
-        self.genPersistKey(parent.inactive)
+        self.genPersistKey()
         parent.active[self.key] = self
 
     @locked
     def blocked(self, parent):
         self._blocked = True
-        self.genPersistKey(parent.inactive)
+        self.genPersistKey()
         parent.active[self.key] = self
 
     @locked
     def unblocked(self, parent):
         self._blocked = False
-        self.genPersistKey(parent.inactive)
+        self.genPersistKey()
         parent.active[self.key] = self
 
     @locked
     def start(self, parent):
         self._start = utcNow()
         parent.inactive.lastKey = self.key
-        self.genPersistKey(parent.inactive)
+        self.genPersistKey()
         parent.active[self.key] = self
 
     @locked
@@ -327,7 +325,7 @@ class JobInfo(object):
         self._rc = rc
         self.pid = None
         del parent.active[self.key]
-        self.genPersistKey(parent.inactive)
+        self.genPersistKey()
         k = self.persistKey(parent.inactive)
         parent.inactive[k] = self
 

--- a/jobrunner/info.py
+++ b/jobrunner/info.py
@@ -9,6 +9,7 @@ import dateutil.tz
 
 import jobrunner.utils as utils
 
+from .service import service
 from .utils import (
     dateTimeFromJson,
     dateTimeToJson,
@@ -564,7 +565,7 @@ def decodeJobInfo(odict):
     if '_uidx' not in odict:
         return odict
     uidx = odict['_uidx']
-    newJob = JobInfo(uidx)
+    newJob = service().db.jobInfo(uidx)
     for dateTimeKey in DATETIME_KEYS:
         odict[dateTimeKey] = dateTimeFromJson(odict.get(dateTimeKey))
     odict['_alldeps'] = set(odict.get('_alldeps', set()))

--- a/jobrunner/service/registry.py
+++ b/jobrunner/service/registry.py
@@ -1,4 +1,5 @@
 from . import service
+from ..db import JobInfo
 from ..db.dbm_db import DbmJobs
 from ..db.sqlite_db import Sqlite3Jobs
 
@@ -8,3 +9,4 @@ def registerServices(sqlite=False):
         service().register("db.jobs", Sqlite3Jobs)
     else:
         service().register("db.jobs", DbmJobs)
+    service().register("db.jobInfo", JobInfo)

--- a/jobrunner/service/registry.py
+++ b/jobrunner/service/registry.py
@@ -4,7 +4,9 @@ from ..db.dbm_db import DbmJobs
 from ..db.sqlite_db import Sqlite3Jobs
 
 
-def registerServices(sqlite=False):
+def registerServices(sqlite=False, testing=False):
+    if testing:
+        service().clear(thisIsATest=testing)
     if sqlite:
         service().register("db.jobs", Sqlite3Jobs)
     else:

--- a/jobrunner/test/info_test.py
+++ b/jobrunner/test/info_test.py
@@ -14,7 +14,7 @@ from .helpers import resetEnv
 
 def setUpModule():
     resetEnv()
-    registerServices()
+    registerServices(testing=True)
     os.environ['HOSTNAME'] = 'testHostname'
     os.environ['USER'] = 'somebody'
     if 'WP' in os.environ:

--- a/jobrunner/test/info_test.py
+++ b/jobrunner/test/info_test.py
@@ -7,12 +7,14 @@ import mock
 import simplejson as json
 
 from jobrunner import db, info, plugins, utils
+from jobrunner.service.registry import registerServices
 
 from .helpers import resetEnv
 
 
 def setUpModule():
     resetEnv()
+    registerServices()
     os.environ['HOSTNAME'] = 'testHostname'
     os.environ['USER'] = 'somebody'
     if 'WP' in os.environ:

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
     {envbindir}/isort -c --diff -rc {[defs]filespec}
     {envbindir}/autopep8 --exit-code -ra --diff {[defs]filespec}
     {envbindir}/pylint -d fixme {[defs]filespec}
-    {envbindir}/pytest -v -l --junitxml=junit/test-results.xml
+    {envbindir}/pytest -v -l --junitxml=junit/test-results.xml --durations=10
 
 [testenv:pip-compile]
 deps = pip-tools


### PR DESCRIPTION
There doesn't seem to be any good reason for the "Not a valid entry"
sentinel values in the inactive DB for jobs that are still running.

This fixes a bug where `--prune` would crash while jobs are running.