### PR TITLE
test: ignore rmtree errors

### DIFF
--- a/jobrunner/test/integration/integration_lib.py
+++ b/jobrunner/test/integration/integration_lib.py
@@ -58,7 +58,7 @@ def testEnv():
         yield Env(tmpDir)
     finally:
         print('rmTree', tmpDir)
-        rmtree(tmpDir)
+        rmtree(tmpDir, ignore_errors=True)
         os.environ['JOBRUNNER_STATE_DIR'] = '/tmp/BADDIR'
 
 


### PR DESCRIPTION
For some reason, the Mojave job started having random errors while
cleaning up the DB state dir, (no such file in rmtree), so just
pass ignore_errors=True.