### PR TITLE
 safe-print: add exception-guarded `sprint` helper

### DIFF
--- a/job
+++ b/job
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function
 import argparse
 import errno
 import hashlib
+import logging
 import os
 from subprocess import PIPE, CalledProcessError, Popen, check_call, check_output
 import sys
@@ -32,6 +33,8 @@ from jobrunner.utils import (
     showMsgs,
 )
 
+LOG = logging.getLogger(__name__)
+
 
 def main(args=None):
     # pylint: disable=too-many-branches
@@ -46,7 +49,18 @@ def main(args=None):
     config = Config(options)
     jobs = service().db.jobs(config, plugins)
 
-    maybeStartDebugger(options)
+    fmt = (
+        '+%(process)-6d %(levelname)-9s '
+        '%(name)-20s %(filename)20s:%(lineno)-5d '
+        '[%(asctime)s] %(message)s')
+    if options.debug:
+        logging.basicConfig(
+            filename='/tmp/job.log',
+            level=logging.DEBUG,
+            format=fmt)
+    else:
+        logging.basicConfig(stream=sys.stderr, level=logging.ERROR, format=fmt)
+    LOG.debug("starting with args %s", options)
     jobs.lock()
     maybeHandleNonExecOptions(options, jobs)
     maybeHandleNonExecWriteOptions(options, jobs)
@@ -118,6 +132,7 @@ def main(args=None):
         jobs.unlock()
         childPid = os.fork()
         if childPid > 0:
+            LOG.info("forked child %d", childPid)
             if options.monitor:
                 monitor = ["tail", "-n+0", "-f", job.logfile]
                 print("Monitoring with 'tail -f', use Ctrl-C to stop "
@@ -141,15 +156,18 @@ def main(args=None):
             while deps:
                 job.setDependencies(jobs, deps)
                 dep = deps.pop(0)
+                LOG.debug("wait for dep %s", dep)
                 jobs.waitFor(dep, options.verbose)
                 mailDeps.append(dep)
         except KeyboardInterrupt:
             print("\ninterrupted")
             aborted = True
         finally:
+            LOG.debug("unlocked %s", job, exc_info=1)
             job.unblocked(jobs)
             job.setDependencies(jobs, None)
     if aborted:
+        LOG.debug("aborted %s", job)
         job.stop(jobs, STOP_ABORT)
         jobs.unlock()
         sys.exit(-1)
@@ -169,6 +187,7 @@ def main(args=None):
             sys.exit(j.rc)
 
     job.start(jobs)
+    LOG.debug("started job %s", job)
     if cmd is None and options.reminder is not None:
         print("reminder: '%s'" % options.reminder)
         jobs.unlock()
@@ -228,10 +247,13 @@ def postCommand(cmd):
 
 
 def finish(job, rc):
+    LOG.debug("finish %s", job)
     doMsg("key:", job.key)
+    LOG.debug("first doMsg is OK %s", job)
     doMsg("return code:", rc)
     robotInfo("finish", {"key": job.key}, {"rc": rc})
     if rc != 0 and quiet():
+        LOG.debug("calling showMsgs for job %s", job)
         showMsgs()
 
 
@@ -668,26 +690,6 @@ def parseArgs(args=None):
     return options
 
 
-def maybeStartDebugger(options):
-    if options.debug:
-        doneDebug = False
-        try:
-            import pudb
-            pudb.set_trace()
-            doneDebug = True
-        except ImportError:
-            pass
-
-        try:
-            if not doneDebug:
-                import pdb
-                pdb.set_trace()  # pylint: disable=no-member
-                doneDebug = True
-        except ImportError:
-            pass
-        assert doneDebug, "no debugger was started"
-
-
 def maybeHandle(options, jobs, handler):
     try:
         handled = handler(options, jobs)
@@ -710,6 +712,7 @@ def maybeHandleNonExecWriteOptions(options, jobs):
 def runJob(cmd, options, jobs, job, fp, doIsolate):
     # pylint: disable=too-many-arguments
     # pylint: disable=too-many-statements
+    LOG.info("execute: %s", job.cmdStr)
     doMsg("execute:", job.cmdStr)
     robotInfo("execute", {"key": job.key}, {"command": job.cmdStr})
     fpIn = open(options.input, "r")
@@ -729,24 +732,35 @@ def runJob(cmd, options, jobs, job, fp, doIsolate):
         cmd = netnsd
     try:
         jobs.unlock()
+        LOG.debug("starting check_call()")
         rc = check_call(cmd, stdin=fpIn, stdout=fp, stderr=fp)
+        LOG.debug("check_call() => rc=%d", rc)
     except KeyboardInterrupt:
         print("\ninterrupted")
+        LOG.debug("KeyboardInterrupt", exc_info=1)
         rc = -1
     except OSError as err:
+        LOG.debug("OSError %s", err, exc_info=1)
         rc = -1 * err.errno
         print(err, file=open(job.logfile, 'a'))
     except CalledProcessError as err:
+        LOG.debug("CalledProcessError %s", err, exc_info=1)
         rc = err.returncode
     except Exception:
+        LOG.debug("General exception", exc_info=1)
         rc = -1
         raise
     finally:
+        LOG.debug("stop job, it has finished %s", job, exc_info=1)
         jobs.lock()
+        LOG.debug("locked DB, writing 'stop' status rc=%d", rc)
         job.stop(jobs, rc)
         os.fsync(fp)
+        LOG.debug("locked DB, writing 'finish' status rc=%d", rc)
         finish(job, rc)
         jobs.unlock()
+        LOG.debug("unlocked, should now exit rc=%d", rc)
+    LOG.debug("exit rc=%d", rc)
     sys.exit(rc)
 
 

--- a/job
+++ b/job
@@ -31,6 +31,7 @@ from jobrunner.utils import (
     robotInfo,
     setQuiet,
     showMsgs,
+    sprint,
 )
 
 LOG = logging.getLogger(__name__)
@@ -96,11 +97,11 @@ def main(args=None):
     elif options.retry:
         oldJob = jobs.getJobMatch(options.retry, options.tw)
         if os.getcwd() != oldJob.pwd:
-            print(
+            sprint(
                 "NOTE: Changing directory to '%s' to retry job." %
                 oldJob.pwd)
             os.chdir(oldJob.pwd)
-        print("retry job '%s'" % oldJob.cmdStr)
+        sprint("retry job '%s'" % oldJob.cmdStr)
         cmd = oldJob.cmd
         if oldJob.isolate:
             doIsolate = oldJob.isolate
@@ -113,7 +114,7 @@ def main(args=None):
     elif options.wait:
         pass
     else:
-        print(jobs.getLog(key=None, thisWs=options.tw, skipReminders=True))
+        sprint(jobs.getLog(key=None, thisWs=options.tw, skipReminders=True))
         jobs.unlock()
         sys.exit(0)
 
@@ -135,8 +136,8 @@ def main(args=None):
             LOG.info("forked child %d", childPid)
             if options.monitor:
                 monitor = ["tail", "-n+0", "-f", job.logfile]
-                print("Monitoring with 'tail -f', use Ctrl-C to stop "
-                      "monitoring\n\n")
+                sprint("Monitoring with 'tail -f', use Ctrl-C to stop "
+                       "monitoring\n\n")
                 sys.stdout.flush()
                 os.execvp(monitor[0], monitor)
             sys.exit(0)
@@ -160,7 +161,7 @@ def main(args=None):
                 jobs.waitFor(dep, options.verbose)
                 mailDeps.append(dep)
         except KeyboardInterrupt:
-            print("\ninterrupted")
+            sprint("\ninterrupted")
             aborted = True
         finally:
             LOG.debug("unlocked %s", job, exc_info=1)
@@ -180,16 +181,16 @@ def main(args=None):
             os.write(fp, "Dependent job failed: %s\n" % j)
             os.write(fp, j.detail("vvv") + "\n")
             job.stop(jobs, STOP_DEPFAIL)
-            print("\nDependent job failed: %s" % j)
-            print("key: %s" % job.key)
-            print("return code: %d" % j.rc)
+            sprint("\nDependent job failed: %s" % j)
+            sprint("key: %s" % job.key)
+            sprint("return code: %d" % j.rc)
             jobs.unlock()
             sys.exit(j.rc)
 
     job.start(jobs)
     LOG.debug("started job %s", job)
     if cmd is None and options.reminder is not None:
-        print("reminder: '%s'" % options.reminder)
+        sprint("reminder: '%s'" % options.reminder)
         jobs.unlock()
         sys.exit(0)
 
@@ -229,9 +230,9 @@ def waitForDep(depWait, options, jobs):
         jobs.waitInactive(k, options.verbose)
         j = jobs.inactive[k]
         if j.rc != 0:
-            print("\nDependent job failed: %s" % j)
-            print("key: %s" % j.key)
-            print("return code: %d" % j.rc)
+            sprint("\nDependent job failed: %s" % j)
+            sprint("key: %s" % j.key)
+            sprint("return code: %d" % j.rc)
             return j.rc
     return 0
 
@@ -386,7 +387,7 @@ def handleNonExecOptions(options, jobs):
             filterPane=options.tp,
             useCp=options.since_checkpoint)
         if options.dot:
-            print(dot)
+            sprint(dot)
         else:
             fName = '~%s/output/job.svg' % os.getenv('USER')
             ofile = os.path.expanduser(fName)
@@ -396,13 +397,13 @@ def handleNonExecOptions(options, jobs):
             if stdout.strip() or stderr.strip():
                 raise ExitCode(stdout + stderr)
             else:
-                print('Saved output to', fName)
+                sprint('Saved output to', fName)
         return True
     elif options.list_inactive:
         jobs.listInactive(options.tw, options.tp, options.since_checkpoint)
         return True
     elif options.count:
-        print(jobs.countInactive())
+        sprint(jobs.countInactive())
         return True
     elif options.get_all_logs:
         logs = []
@@ -411,39 +412,39 @@ def handleNonExecOptions(options, jobs):
                                    filterPane=options.tp,
                                    useCp=options.since_checkpoint):
             logs.append(job.logfile)
-        print(" ".join(logs))
+        sprint(" ".join(logs))
         return True
     elif options.get_log:
         logs = []
         for key in options.get_log:
             logs.append(jobs.getLog(key, options.tw))
-        print(" ".join(logs))
+        sprint(" ".join(logs))
         return True
     elif options.show:
         for k in options.show:
             j = jobs.getJobMatch(k, options.tw)
-            print(j.detail(options.verbose))
+            sprint(j.detail(options.verbose))
         return True
     elif options.pid:
         for key in options.pid:
             try:
                 showPstreeForKey(key, jobs, options)
             except KeyError as error:
-                print("Error:", error.message)
+                sprint("Error:", error.message)
         return True
     elif options.last_key:
-        print(jobs.inactive.lastKey)
+        sprint(jobs.inactive.lastKey)
         return True
     elif options.index:
         logs = []
         for index in options.index:
             logs.append(jobs.getLogByIndex(index, options.tw))
-        print(" ".join(logs))
+        sprint(" ".join(logs))
         jobs.unlock()
         sys.exit(0)
     elif options.info:
-        print(jobs.active)
-        print(jobs.inactive)
+        sprint(jobs.active)
+        sprint(jobs.inactive)
         return True
     elif options.activity or options.activity_window:
         jobs.activityWindow(options)
@@ -461,7 +462,7 @@ def handleNonExecWriteOptions(options, jobs):
             try:
                 j = jobs.getJobMatch(k, options.tw)
                 if j.key in jobs.active:
-                    print("Stopping job:", j)
+                    sprint("Stopping job:", j)
                     j.stop(jobs, STOP_STOP)
                 else:
                     errors.append(j.key)
@@ -483,7 +484,7 @@ def handleNonExecWriteOptions(options, jobs):
         for k in options.done:
             j = jobs.getJobMatch(k, options.tw)
             if j.reminder:
-                print('Done with reminder: "%s"' % j.reminder)
+                sprint('Done with reminder: "%s"' % j.reminder)
             j.stop(jobs, STOP_DONE)
         return True
     elif options.prune:
@@ -495,7 +496,7 @@ def handleNonExecWriteOptions(options, jobs):
     elif options.delete:
         for k in options.delete:
             j = jobs.inactive[k]
-            print("Delete job '%s'" % j.key)
+            sprint("Delete job '%s'" % j.key)
             j.removeLog(verbose=True)
             del jobs.inactive[j.key]
         return True
@@ -504,14 +505,14 @@ def handleNonExecWriteOptions(options, jobs):
         jobs.inactive.checkpoint = options.set_checkpoint
         cpUtc = jobs.active.checkpoint
         local = cpUtc.astimezone(dateutil.tz.tzlocal())
-        print("Set checkpoint: ", local.strftime(DATETIME_FMT))
+        sprint("Set checkpoint: ", local.strftime(DATETIME_FMT))
         return True
     elif options.watch:
         try:
             jobs.watchActivity()
         except KeyboardInterrupt:
-            print("")
-            print("Exit on user interrupt")
+            sprint("")
+            sprint("Exit on user interrupt")
             raise ExitCode(1)
         return True
     else:
@@ -556,21 +557,21 @@ def getPstree(pid):
 
 def showPstreeForKey(key, jobs, options):
     j = jobs.getJobMatch(key, options.tw)
-    print("==============================================")
-    print(j)
+    sprint("==============================================")
+    sprint(j)
     if pidOk(j.pid):
         pstree = getPstree(j.pid)
         if not pstree.errors:
-            print(pstree.text)
+            sprint(pstree.text)
         elif pidOk(j.pid):
-            print("Errors getting PID info for", j.pid)
+            sprint("Errors getting PID info for", j.pid)
             for err in pstree.errors:
-                print(err)
+                sprint(err)
         else:
-            print("PID not found", j.pid)
+            sprint("PID not found", j.pid)
     else:
-        print("PID not found", j.pid)
-    print("==============================================")
+        sprint("PID not found", j.pid)
+    sprint("==============================================")
 
 
 def parseArgs(args=None):
@@ -676,7 +677,7 @@ def parseArgs(args=None):
                     help="Specify input file (default='%(default)s')",
                     default="/dev/null")
     op.add_argument("--debug", action="store_true",
-                    help="Launch debugger to examine database")
+                    help="enable debug output to /tmp/job.log")
     op.add_argument("--debugLocking", dest="debugLevel", action="append_const",
                     const="lock", help="Debug database locking")
     op.add_argument("--auto-job", action="store_true",
@@ -727,8 +728,8 @@ def runJob(cmd, options, jobs, job, fp, doIsolate):
         netnsd = ['isolate', '-n', isolateName]
         netnsd += cmd
         if options.verbose:
-            print('Isolating command WAS:', cmd)
-            print('Isolating command IS :', netnsd)
+            sprint('Isolating command WAS:', cmd)
+            sprint('Isolating command IS :', netnsd)
         cmd = netnsd
     try:
         jobs.unlock()
@@ -736,13 +737,13 @@ def runJob(cmd, options, jobs, job, fp, doIsolate):
         rc = check_call(cmd, stdin=fpIn, stdout=fp, stderr=fp)
         LOG.debug("check_call() => rc=%d", rc)
     except KeyboardInterrupt:
-        print("\ninterrupted")
         LOG.debug("KeyboardInterrupt", exc_info=1)
+        sprint("\ninterrupted")
         rc = -1
     except OSError as err:
         LOG.debug("OSError %s", err, exc_info=1)
         rc = -1 * err.errno
-        print(err, file=open(job.logfile, 'a'))
+        sprint(err, file=open(job.logfile, 'a'))
     except CalledProcessError as err:
         LOG.debug("CalledProcessError %s", err, exc_info=1)
         rc = err.returncode

--- a/jobrunner/db/__init__.py
+++ b/jobrunner/db/__init__.py
@@ -24,6 +24,7 @@ from ..utils import (
     doMsg,
     pidDebug,
     safeSleep,
+    sprint,
     stackDetails,
     utcNow,
 )
@@ -273,7 +274,7 @@ class JobsBase(object):
         if len(allJobs) > limit:
             for job in allJobs[: -1 * limit]:
                 if self.config.verbose:
-                    print("Prune '%s'" % job.key)
+                    sprint("Prune '%s'" % job.key)
                 job.removeLog(self.config.verbose)
                 del self.inactive[job.key]
 
@@ -316,7 +317,7 @@ class JobsBase(object):
     @staticmethod
     def printDepJob(job, depth):
         fmt = "%%-%ds->" % (depth * 2)
-        print(fmt % "", job)
+        sprint(fmt % "", job)
         return True
 
     def printDepTree(self, db, depends):
@@ -350,23 +351,23 @@ class JobsBase(object):
                 hasDeps = self.walkDepTree(
                     lambda j, d: d == 1, db, job.depends, 1)
         if hasDeps:
-            print(utils.SPACER)
+            sprint(utils.SPACER)
         for job in jobList:
             if not includeReminders and job.reminder:
                 continue
             if self.config.verbose:
-                print(job.detail(self.config.verbose[1:]))
+                sprint(job.detail(self.config.verbose[1:]))
             else:
                 if db is self.active:
-                    print(job)
+                    sprint(job)
                     if job.depends:
                         self.printDepTree(db, job.depends)
                     if hasDeps:
-                        print(utils.SPACER)
+                        sprint(utils.SPACER)
                 else:
-                    print(job)
+                    sprint(job)
         if not jobList:
-            print("(None)")
+            sprint("(None)")
 
     @staticmethod
     def dotStrForKey(key, active, inactive, attrs=False):
@@ -538,7 +539,7 @@ class JobsBase(object):
         if func():
             return
         if verbose:
-            print("\nWaiting for %s" % desc)
+            sprint("\nWaiting for %s" % desc)
         while not func():
             safeSleep(1, self)
             if verbose:
@@ -583,7 +584,7 @@ class JobsBase(object):
             clearNum = clearLen - len(details)
             if clearNum < 0:
                 clearNum = 0
-            print("%s" % timestr + details + " " * clearNum)
+            sprint("%s" % timestr + details + " " * clearNum)
 
     def getResources(self):
         loads = ['%.0f' % v for v in os.getloadavg()]
@@ -673,7 +674,7 @@ class JobsBase(object):
             if not j.reminder:
                 continue
             if not j.startTime:
-                print('not started yet', str(j), j.workspace)
+                sprint('not started yet', str(j), j.workspace)
                 continue
             remind.setdefault(j.workspace, []).append(j)
         for k in self.inactive.keys():
@@ -722,13 +723,13 @@ class JobsBase(object):
                 return 1
             else:
                 return cmp(perWs[refA]['age'], perWs[refB]['age'])
-        print('-' * 75)
+        sprint('-' * 75)
         wsList = list(set(perWs.keys()).union(set(remind.keys())))
         for wkspace in sorted(wsList, cmp=_byAge):
             if wkspace:
-                print(os.path.basename(wkspace) + ':')
+                sprint(os.path.basename(wkspace) + ':')
             else:
-                print('Outside of any workspace:')
+                sprint('Outside of any workspace:')
             for res in ['pass', 'fail']:
                 if wkspace in perWs and res in perWs[wkspace]:
                     j = perWs[wkspace][res]
@@ -738,16 +739,16 @@ class JobsBase(object):
                     tmMin = sec / 60
                     sec -= tmMin * 60
                     diffTime = '%d:%02d:%02d' % (tmHour, tmMin, sec)
-                    print(
+                    sprint(
                         '  last %s, \033[97m%s\033[0m ago' %
                         (res, diffTime))
-                    print('    ' + str(j))
+                    sprint('    ' + str(j))
             if wkspace in remind:
-                print('  reminders:')
+                sprint('  reminders:')
                 for j in remind[wkspace]:
-                    print('    \033[92m%s\033[0m' % j.reminder)
-            print('')
-        print('-' * 75)
+                    sprint('    \033[92m%s\033[0m' % j.reminder)
+            sprint('')
+        sprint('-' * 75)
 
     def addDeps(self, fromWhere, thisWs, deps, depSuccess):
         if fromWhere:

--- a/jobrunner/db/__init__.py
+++ b/jobrunner/db/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from datetime import datetime
+import logging
 import os
 import os.path
 import sys
@@ -31,6 +32,8 @@ NUM_RECENT = 100
 PRUNE_NUM = 5000
 
 # pylint: disable=deprecated-lambda
+LOG = logging.getLogger(__name__)
+LOGLOCK = logging.getLogger(__name__ + ".lock")
 
 
 class DatabaseMeta(object):
@@ -250,9 +253,11 @@ class JobsBase(object):
         raise NotImplementedError
 
     def lock(self):
+        LOGLOCK.debug("lock DB")
         self.debugPrint("< LOCK DB")
 
     def unlock(self):
+        LOGLOCK.debug("unlock DB")
         self.debugPrint("< UNLOCK DB")
 
     def prune(self, exceptNum=None):

--- a/jobrunner/info.py
+++ b/jobrunner/info.py
@@ -17,6 +17,7 @@ from .utils import (
     keyEscape,
     locked,
     robotInfo,
+    sprint,
     unlocked,
     utcNow,
     workspaceIdentity,
@@ -332,12 +333,12 @@ class JobInfo(object):
     @unlocked
     def killPgrp(self, jobs):
         if not self.pid:
-            print("Not running")
+            sprint("Not running")
             return
         try:
             pgrp = os.getpgid(self.pid)
         except OSError as error:
-            print("Unable to get process group for", self.pid, error)
+            sprint("Unable to get process group for", self.pid, error)
             if error.errno != errno.ESRCH:
                 raise
             pgrp = None
@@ -346,11 +347,11 @@ class JobInfo(object):
             try:
                 killed = utils.killProcGroup(pgrp, jobs)
             except OSError as error:
-                print("Unable to kill process group", pgrp, error)
-        if not killed:
+                sprint("Unable to kill process group", pgrp, error)
+        if pgrp and not killed:
             error = utils.sudoKillProcGroup(pgrp)
             if error:
-                print("Failed to kill with sudo as well:", error)
+                sprint("Failed to kill with sudo as well:", error)
 
     @locked
     def pidIs(self, parent, pid):
@@ -366,7 +367,7 @@ class JobInfo(object):
     def removeLog(self, verbose):
         if os.access(self.logfile, os.F_OK):
             if verbose:
-                print("Remove logfile '%s'" % self.logfile)
+                sprint("Remove logfile '%s'" % self.logfile)
             os.unlink(self.logfile)
 
     @staticmethod

--- a/jobrunner/utils.py
+++ b/jobrunner/utils.py
@@ -6,6 +6,7 @@ import datetime
 import errno
 import fcntl
 import inspect
+import logging
 import os
 import signal
 import subprocess
@@ -25,6 +26,8 @@ SPECIAL_STATUS = [STOP_STOP, STOP_ABORT, STOP_DONE, STOP_DEPFAIL]
 
 SPACER_EACH = "========================================"
 SPACER = SPACER_EACH + SPACER_EACH
+
+LOG = logging.getLogger(__name__)
 
 
 class ModState(object):
@@ -184,12 +187,16 @@ def robot():
 
 def doMsg(*args):
     msg = " ".join(map(str, args))
+    LOG.debug("doMsg(%s)", repr(args))
     if quiet():
+        LOG.debug("enqueue message")
         _DEBUGGER.msgQueue.append(msg)
     elif robot():
+        LOG.debug("robot - skip message")
         return
     else:
         print(msg)
+        LOG.debug("print message")
 
 
 def robotInfo(*info):
@@ -209,7 +216,9 @@ def robotInfo(*info):
 
 def showMsgs():
     print('\n'.join(_DEBUGGER.msgQueue) + '\n')
+    LOG.debug("showMsgs for %d messages", len(_DEBUGGER.msgQueue))
     _DEBUGGER.msgQueue = []
+    LOG.debug("showMsgs finished")
 
 
 def killWithSignal(pgrp, signum):


### PR DESCRIPTION
This is a drop-in replacement for the `print` function, added because when jobs were
started and then the controlling terminal closed, they might error out at the end of
the job (if not running with --quiet, or if there was an error message to print out
from the message queue) with an IOError.

In the case of IOError from `print`, just discard it and continue.  For all other
exceptions, re-raise.