### PR TITLE
info: Fix env printing

### DIFF
--- a/jobrunner/info.py
+++ b/jobrunner/info.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from curses.ascii import isprint
 import errno
+from logging import getLogger
 import os
 import pipes
+import string
 
 import dateutil.tz
 
@@ -22,6 +23,8 @@ from .utils import (
     utcNow,
     workspaceIdentity,
 )
+
+LOG = getLogger(__name__)
 
 
 def getUtcTime(val):
@@ -370,14 +373,22 @@ class JobInfo(object):
                 sprint("Remove logfile '%s'" % self.logfile)
             os.unlink(self.logfile)
 
+    printable = string.printable.translate(None, '\r\n\t\v\x0c')
+
     @staticmethod
     def escEnv(value):
         ret = ""
+        LOG.debug('value [%r]', value)
+        LOG.debug(
+            'printable [%r] (string.printable [%r])',
+            JobInfo.printable,
+            string.printable)
         for char in value:
-            if isprint(char):
+            if char in JobInfo.printable:
                 ret += char
             else:
                 ret += "\\x%02x" % ord(char)
+        LOG.debug('ret [%r]', ret)
         return ret
 
     def getEnvironment(self):

--- a/jobrunner/test/info_test.py
+++ b/jobrunner/test/info_test.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+from logging import getLogger
 import os
 import unittest
 
@@ -10,6 +11,8 @@ from jobrunner import db, info, plugins, utils
 from jobrunner.service.registry import registerServices
 
 from .helpers import resetEnv
+
+LOG = getLogger(__name__)
 
 
 def setUpModule():
@@ -91,7 +94,7 @@ class TestJobProperties(unittest.TestCase):
     def testEnv(self):
         job = newJob(14, ['ls', '/tmp'])
         job.start(job.parent)
-        env = {'XY': '1', 'VAL_WITH_NEWLINE': 'first\nsecond'}
+        env = {'XY': u'1', 'VAL_WITH_NEWLINE': 'first\nsecond'}
         setJobEnv(job, env)
         out = job.getEnvironment()
         self.assertIn("XY=1\n", out)
@@ -127,3 +130,11 @@ class TestInfoHelpers(unittest.TestCase):
     def testCmdStringBang(self):
         cmd = ['ls', '-l', '!something']
         self.assertEqual(info.cmdString(cmd), "ls -l '!something'")
+
+    def testEscEnv(self):
+        value = '12\x00\x01\n'
+        exp = '12\\x00\\x01\\x0a'
+        out = info.JobInfo.escEnv(value)
+        LOG.debug('exp [%r] %s', exp, exp)
+        LOG.debug('out [%r] %s', out, out)
+        self.assertEqual(exp, out)

--- a/jobrunner/test/integration/integration_lib.py
+++ b/jobrunner/test/integration/integration_lib.py
@@ -62,26 +62,26 @@ def testEnv():
         os.environ['JOBRUNNER_STATE_DIR'] = '/tmp/BADDIR'
 
 
-def run(cmd, capture=False):
+def run(cmd, capture=False, env=None):
     print(' '.join(map(quote, cmd)))
     try:
         if capture:
-            return check_output(cmd, stderr=STDOUT)
+            return check_output(cmd, stderr=STDOUT, env=env)
         else:
-            return check_call(cmd)
+            return check_call(cmd, env=env)
     except CalledProcessError as error:
         print(error.output)
         raise
 
 
-def jobf(*cmd):
+def jobf(*cmd, **kwargs):
     jobCmd = ['job', '--foreground'] + list(cmd)
-    return run(jobCmd, capture=True)
+    return run(jobCmd, capture=True, **kwargs)
 
 
-def job(*cmd):
+def job(*cmd, **kwargs):
     jobCmd = ['job'] + list(cmd)
-    return run(jobCmd, capture=True)
+    return run(jobCmd, capture=True, **kwargs)
 
 
 def waitFor(func, timeout=60.0, failArg=True):


### PR DESCRIPTION
job -vvv Environment section shows all characters in hex encoding.  This was a result
of storing the job info in the database as unicode.

Added an intergration test case to the smoke test and updated existing unit tests. 

Fixes issue #42 