### PR TITLE
info: escape non-ascii in info.cmdString

### DIFF
--- a/jobrunner/info.py
+++ b/jobrunner/info.py
@@ -33,8 +33,12 @@ def getUtcTime(val):
     return val
 
 
+_TRANSLATION = {val: '<{:02X}>'.format(val) for val in range(0x80, 0x100)}
+
+
 def cmdString(cmd):
-    return " ".join(map(pipes.quote, cmd))
+    unicodeString = " ".join(map(pipes.quote, cmd))
+    return "".join(_TRANSLATION.get(ord(c), c) for c in unicodeString)
 
 
 class JobInfo(object):

--- a/jobrunner/test/info_test.py
+++ b/jobrunner/test/info_test.py
@@ -119,17 +119,27 @@ class TestJobProperties(unittest.TestCase):
 
 
 class TestInfoHelpers(unittest.TestCase):
+    def _assertCmd(self, actual, expected):
+        actual.encode('ascii')
+        self.assertEqual(actual, expected)
+
     def testCmdString(self):
         cmd = ['ls', '-l', 'some file']
-        self.assertEqual(info.cmdString(cmd), "ls -l 'some file'")
+        self._assertCmd(info.cmdString(cmd), "ls -l 'some file'")
         cmd = ['ls', '-l', 'some\tfile']
-        self.assertEqual(info.cmdString(cmd), "ls -l 'some\tfile'")
+        self._assertCmd(info.cmdString(cmd), "ls -l 'some\tfile'")
+        cmd = [u'ls', u'-l', u'some\tfile']
+        self._assertCmd(info.cmdString(cmd), "ls -l 'some\tfile'")
         cmd = ['ls', '-l', 'some;file']
-        self.assertEqual(info.cmdString(cmd), "ls -l 'some;file'")
+        self._assertCmd(info.cmdString(cmd), "ls -l 'some;file'")
 
     def testCmdStringBang(self):
-        cmd = ['ls', '-l', '!something']
-        self.assertEqual(info.cmdString(cmd), "ls -l '!something'")
+        cmd = [u'ls', u'-l', u'!something']
+        self._assertCmd(info.cmdString(cmd), "ls -l '!something'")
+
+    def testCmdStringEncodingError(self):
+        cmd = [u'foo', u'bar\xa0', u'zoo']
+        self._assertCmd(info.cmdString(cmd), "foo 'bar<A0>' zoo")
 
     def testEscEnv(self):
         value = '12\x00\x01\n'


### PR DESCRIPTION
For whatever reason, I had jobs with \xa0 characters in the command, and this was
causing a UnicodeDecodeError when listing / displaying job details.

Map all characters from 0x80 to 0xFF (inclusive) to "<80>" -> "<FF>" so that they
are displayed correctly.