### PR TITLE
ui: change output order for retry jobs

### DIFF
--- a/job
+++ b/job
@@ -65,13 +65,6 @@ def main(args=None):
     maybeHandleNonExecWriteOptions(options, jobs)
 
     setQuiet(options.quiet)
-    deps = []
-    depSuccess = []
-    depWait = []
-    jobs.addDeps(options.blocked_by, options.tw, deps, None)
-    jobs.addDeps(options.wait, options.tw, deps, depWait)
-    jobs.addDeps(options.blocked_by_success, options.tw, deps, depSuccess)
-    jobs.addDeps(options.mail, options.tw, deps, None)
 
     doIsolate = options.isolate
     cmd = []
@@ -119,6 +112,14 @@ def main(args=None):
         sprint(jobs.getLog(key=None, thisWs=options.tw, skipReminders=True))
         jobs.unlock()
         sys.exit(0)
+
+    deps = []
+    depSuccess = []
+    depWait = []
+    jobs.addDeps(options.blocked_by, options.tw, deps, None)
+    jobs.addDeps(options.wait, options.tw, deps, depWait)
+    jobs.addDeps(options.blocked_by_success, options.tw, deps, depSuccess)
+    jobs.addDeps(options.mail, options.tw, deps, None)
 
     if depWait:
         rc = waitForDep(depWait, options, jobs)

--- a/jobrunner/db/__init__.py
+++ b/jobrunner/db/__init__.py
@@ -755,7 +755,7 @@ class JobsBase(object):
             for k in fromWhere:
                 depJob = self.getJobMatch(k, thisWs)
                 if depJob.key in self.active:
-                    doMsg("adding dependency:", depJob)
+                    doMsg(" - adding dependency:", depJob)
                 deps.append(depJob)
                 if depSuccess is not None:
                     depSuccess.append(depJob)

--- a/jobrunner/info.py
+++ b/jobrunner/info.py
@@ -234,7 +234,7 @@ class JobInfo(object):
         self._key = (utcNow().strftime("%s") +
                      str(self._uidx) + "_" +
                      keyEscape(keySource))
-        doMsg("set key", self._key)
+        doMsg(" - set key", self._key)
         robotInfo("new", {"key": self._key})
         return self._key
 


### PR DESCRIPTION
When retrying a job that has dependencies, print the 'retry job xxx' message first,
since that's the more important one.

After that, print dependency info, and finally, print the job key.  Also, indent the
dependency and key messages for some visual separation e.g.

```
retry job 'do something'
 - adding dependency: 0:00:35 [15924762523803_sleep] sleep 100
 - set key 15924762883805_do
```