### PR TITLE
env: make autopep8 happy with explicit --indent-size

### DIFF
--- a/format.sh
+++ b/format.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -xe
-FILESPEC="job setup.py jobrunner"
-isort -y -ac -rc $FILESPEC
-autopep8 -j32 -rai $FILESPEC
-pylint $FILESPEC
+FILESPEC=(job setup.py jobrunner)
+isort -y -ac -rc "${FILESPEC[@]}"
+autopep8 -j32 -rai --indent-size=4 "${FILESPEC[@]}"
+pylint "${FILESPEC[@]}"

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ platform = linux2|darwin
 deps = -r requirements.txt
 commands =
     {envbindir}/isort -c --diff -rc {[defs]filespec}
-    {envbindir}/autopep8 --exit-code -ra --diff {[defs]filespec}
+    {envbindir}/autopep8 --indent-size=4 --exit-code -ra --diff {[defs]filespec}
     {envbindir}/pylint -d fixme {[defs]filespec}
     {envbindir}/pytest -v -l --junitxml=junit/test-results.xml --durations=10
 


### PR DESCRIPTION
For some reason it suddenly complains about some imaginary indent-size option in
pycodestyle, seemingly coming from autopep8. :shrugs: