### PR TITLE
ci: add python_version 3.7 to Pipfile to match Pipfile.lock

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -16,3 +16,6 @@ six = "*"
 dateutils = "*"
 requests = "<2.26.0"
 simplejson = "<3.18.0"
+
+[requires]
+python_version = "3.7"


### PR DESCRIPTION
This should hopefully cause dependabot to keep importlib-metadata around, for
example.