### PR TITLE
plugins: add support for entry_points wwade.jobrunner

### DIFF
--- a/jobrunner/plugins.py
+++ b/jobrunner/plugins.py
@@ -2,6 +2,9 @@ from __future__ import absolute_import, division, print_function
 
 import importlib
 import pkgutil
+import warnings
+
+from importlib_metadata import entry_points
 
 import jobrunner.plugin
 
@@ -9,25 +12,34 @@ import jobrunner.plugin
 class Plugins(object):
     def __init__(self):
         self.plugins = {
-            name: importlib.import_module('jobrunner.plugin.{}'.format(name))
+            plug.load() for plug in entry_points().get(
+                'wwade.jobrunner', [])}
+        deprecatedPlugins = {
+            importlib.import_module('jobrunner.plugin.{}'.format(name))
             for finder, name, ispkg
             in pkgutil.iter_modules(jobrunner.plugin.__path__)
         }
+        if deprecatedPlugins:
+            warnings.warn("Found old-style plugins in jobrunner.plugin: %r. "
+                          "Convert to entry_point 'wwade.jobrunner'" % sorted(
+                              deprecatedPlugins),
+                          DeprecationWarning)
+        self.plugins |= deprecatedPlugins
 
     def _plugDo(self, which, *args, **kwargs):
-        for plugin in self.plugins.values():
+        for plugin in self.plugins:
             if hasattr(plugin, which):
                 getattr(plugin, which)(*args, **kwargs)
 
     def getResources(self, jobs):
         ret = ""
-        for plugin in self.plugins.values():
+        for plugin in self.plugins:
             if hasattr(plugin, 'getResources'):
                 ret += plugin.getResources(jobs)
         return ret
 
     def workspaceIdentity(self):
-        for plugin in self.plugins.values():
+        for plugin in self.plugins:
             if hasattr(plugin, 'workspaceIdentity'):
                 ret = plugin.workspaceIdentity()
                 if ret:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='jobrunner',
-    version='2.0.0',
+    version='2.1.0',
     description='Job runner with logging',
     packages=find_packages(exclude=[
         'jobrunner.test',


### PR DESCRIPTION
This will replace the old hacky plugins installed in jobrunner.plugin.
For now, just print a deprecation warning when using the old format.

Bump version to 2.1.0 since this is a significant change. 3.0.0 will remove suppoprt
for the old style plugins completely.