### PR TITLE
plugins: add missing deps to setup.py and fix plugin loader

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ pytest = "*"
 [packages]
 six = "*"
 dateutils = "*"
+importlib-metadata = "*"
 requests = "<2.26.0"
 simplejson = "<3.18.0"
 

--- a/Pipfile-2.7.lock
+++ b/Pipfile-2.7.lock
@@ -1,10 +1,12 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1fa06c851689fd74898664b149d5f24290235f9245604f4ac83d59ba94246359"
+            "sha256": "73e8a1989bd9a9b68075440c43249dbf24f9330944d2fb38e62bd7920ff5ab49"
         },
         "pipfile-spec": 6,
-        "requires": {},
+        "requires": {
+            "python_version": "3.7"
+        },
         "sources": [
             {
                 "name": "pypi",
@@ -163,11 +165,11 @@
         },
         "autopep8": {
             "hashes": [
-                "sha256:9e136c472c475f4ee4978b51a88a494bfcd4e3ed17950a44a988d9e434837bea",
-                "sha256:cae4bc0fb616408191af41d062d7ec7ef8679c7f27b068875ca3a9e2878d5443"
+                "sha256:5454e6e9a3d02aae38f866eec0d9a7de4ab9f93c10a273fb0340f3d6d09f7514",
+                "sha256:f01b06a6808bc31698db907761e5890eb2295e287af53f6693b39ce55454034a"
             ],
             "index": "pypi",
-            "version": "==1.5.5"
+            "version": "==1.5.6"
         },
         "backports.functools-lru-cache": {
             "hashes": [

--- a/jobrunner/plugins.py
+++ b/jobrunner/plugins.py
@@ -21,7 +21,7 @@ class Plugins(object):
         }
         if deprecatedPlugins:
             warnings.warn("Found old-style plugins in jobrunner.plugin: %r. "
-                          "Convert to entry_point 'wwade.jobrunner'" % sorted(
+                          "Convert to entry_point 'wwade.jobrunner'" % list(
                               deprecatedPlugins),
                           DeprecationWarning)
         self.plugins |= deprecatedPlugins

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ setup(
         'jobrunner.test.*',
     ]),
     install_requires=[
+        'six',
         'dateutils',
+        'importlib-metadata',
         'requests<=2.23.0',
         'simplejson<=3.3.0',
     ],


### PR DESCRIPTION
lists of modules are not sortable, so just print out the deprecatedPlugins set as an
unsorted list instead.