### PR TITLE
ui: fix '--pid' for python3 and improve '--int' wrt sudo

### DIFF
--- a/jobrunner/main.py
+++ b/jobrunner/main.py
@@ -14,14 +14,15 @@ import dateutil.parser
 import dateutil.tz
 import six
 
-from jobrunner.argparse import addArgumentParserBaseFlags, baseParsedArgsToArgList
-from jobrunner.binutils import binDescriptionWithStandardFooter
-from jobrunner.config import Config
 import jobrunner.logging
-from jobrunner.plugins import Plugins
-from jobrunner.service import service
-from jobrunner.service.registry import registerServices
-from jobrunner.utils import (
+
+from .argparse import addArgumentParserBaseFlags, baseParsedArgsToArgList
+from .binutils import binDescriptionWithStandardFooter
+from .config import Config
+from .plugins import Plugins
+from .service import service
+from .service.registry import registerServices
+from .utils import (
     DATETIME_FMT,
     MOD_STATE,
     SPACER_EACH,
@@ -29,6 +30,7 @@ from jobrunner.utils import (
     STOP_DEPFAIL,
     STOP_DONE,
     STOP_STOP,
+    autoDecode,
     doMsg,
     keyEscape,
     lockedSection,
@@ -211,7 +213,7 @@ def main(args=None):
             depJob = jobs.inactive[j.permKey]
             safeWrite(tmp, depJob.detail(options.verbose))
             safeWrite(tmp, "\n" + SPACER_EACH + "\n")
-            lines = check_output(['tail', '-n20', depJob.logfile]).decode('utf-8')
+            lines = autoDecode(check_output(['tail', '-n20', depJob.logfile]))
             safeWrite(tmp, lines)
             safeWrite(tmp, SPACER_EACH + "\n")
             safeWrite(tmp, "\n")
@@ -575,7 +577,7 @@ def pidOk(pid):
 
 class Pstree(object):
     def __init__(self, text):
-        self.text = text.strip() if text else None
+        self.text = autoDecode(text).strip() if text else None
         self.errors = []
 
 

--- a/jobrunner/test/integration/interrupt_running_test.py
+++ b/jobrunner/test/integration/interrupt_running_test.py
@@ -10,7 +10,6 @@ from pytest import mark
 from jobrunner.utils import autoDecode
 
 from .integration_lib import (
-    IntegrationTestTimeout,
     job,
     jobf,
     noJobs,
@@ -49,7 +48,6 @@ def setUpModule():
 
 
 class TestInterrupt(TestCase):
-    @mark.xfail(raises=IntegrationTestTimeout)
     def testAsUser(self):
         with testEnv():
             # --pid
@@ -61,6 +59,7 @@ class TestInterrupt(TestCase):
             waitFor(_findJob)
             out = jobf('--pid', 'sleep')
             print("pid", out)
+            self.assertNotIn("b'job", out)
             self.assertIn('sleep', out)
             job('--int', 'sleep')
             try:
@@ -69,7 +68,6 @@ class TestInterrupt(TestCase):
                 pass
             waitFor(noJobs)
 
-    @mark.xfail(raises=IntegrationTestTimeout)
     @mark.skipif(_MODULE.sudoOk != 1, reason="no sudo rights")
     def testWithSudo(self):
         with testEnv():


### PR DESCRIPTION
--pid was not decoding the output from pstree, so it was printing out a byte-array
repr instead. Use the newly added autoDecode for the pstree output.

--int had some problems re-exec'ing python under sudo for virtualenv
installations. We can use sys.executable to ensure that we run the helper kill script
inside the same virtualenv (by reusing sys.executable) so that we're loading the
right jobrunner modules.

Updated the interrupt_running_test to check the --pid output, and also to ensure that
we can actually run the "sudo" test when sudo is available.

The problem causing failures in the integration test before was, presumably, that we
were too quick to kill the process with SIGTERM which means that it will not be able
to update the job db to remove the running job, and so the test thinks the job is
still running, even though it was actually killed. To get around this, send more
SIGINT, first, and then finally, SIGTERM, SIGKILL.