### PR TITLE
main: print error message instead of throwing KeyError

### DIFF
--- a/jobrunner/db/__init__.py
+++ b/jobrunner/db/__init__.py
@@ -41,6 +41,10 @@ LOG = logging.getLogger(__name__)
 LOGLOCK = logging.getLogger(__name__ + ".lock")
 
 
+class NoMatchingJobError(Exception):
+    pass
+
+
 class DatabaseMeta(object):
     # pylint: disable=too-many-instance-attributes
     SV = '_schemaVersion_'
@@ -527,7 +531,7 @@ class JobsBase(object):
             if candidates:
                 return candidates[0]
 
-            raise KeyError("No job for key '%s'" % key)
+            raise NoMatchingJobError("No job for key '%s'" % key)
 
     def getLog(self, key, thisWs, skipReminders=False):
         return self.getJobMatch(key, thisWs, skipReminders).logfile

--- a/test.sh
+++ b/test.sh
@@ -4,7 +4,7 @@ set -xeuo pipefail
 PY=$(python -c "import sys; print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))")
 python -m pip install --upgrade pip setuptools wheel pipenv
 set +x
-mirrorUrl=$(pip config list | grep index-url | cut -d= -f2 | cut -d\' -f2)
+mirrorUrl=$(pip config list | grep index-url | cut -d= -f2 | cut -d\' -f2 || true)
 mirror=()
 if [[ -n "$mirrorUrl" ]]; then
     mirrorUrl=${mirrorUrl/[[:space:]]/}


### PR DESCRIPTION
When a job match isn't found, raise NoMatchingJobError and catch it in main instead
of letting a KeyError go all the way up uncaught.