### PR TITLE
docs: update docs to reflect current dev process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,25 +2,7 @@
 Thanks for helping out!  I'll make every effort to respond to PRs in a relateively short time, once the CI has passed, at least.
 
 ## Development Environment
-### Requirements
-- virtualenv >= 16.7.3 `pip install virtualenv` or `pip install --user virtualenv`
-### Enivronment
-```
-$ git clone git@github.com:wwade/jobrunner.git
-$ cd jobrunner
-$ . testenv
-(venv27)$ 
-```
-### Running Tests
-The full CI test suite
-```
-(venv27)$ tox
-```
-Individual tests can be executed with `nosetests` or `pytest`.  A coverage report for unit tests can be created by running `./cover.sh` from inside the virtualenv.
-To just run unit tests, you can skip the integration tests with `nosetests`:
-```
-(venv27)$ nosetests -e integration
-```
+See [README.rst](README.rst).
 
 ## Guidelines
 1. Please try to keep PRs on a single topic.  Generally this means that they'll invlove a "small" number of commits, and that each commit contains the minimal changes for its purpose.

--- a/README.rst
+++ b/README.rst
@@ -4,6 +4,7 @@ job
 Job runner with logging
 
 |Build Status|
+|PyPI Release|
 
 Installation
 ------------
@@ -101,7 +102,7 @@ Configuration
 -------------
 
 | The default configuration file location is ``~/.config/jobrc``, but can be
-| overwritten using the --rc-file option.
+| overridden using the --rc-file option.
 
 Sample rcfile:
 ~~~~~~~~~~~~~~
@@ -160,11 +161,14 @@ Run CI checks locally
 
 | This allows you to run something similar to the azure pipelines locally using docker.
 | It will use ``PIP_INDEX_URL`` and / or ``~/.config/pip/pip.conf`` to configure a pypi mirror.
-| This will also update ``Pipfile-2.7.lock`` and ``Pipfile.lock``.
+| This will also update ``Pipfile*.lock``.
 
 .. code:: console
 
-    ./test-docker.sh
+    ./test-docker.py [--versions 2.7 3.7 3.8] [--upgrade] [--ignore-unclean]
 
 .. |Build Status| image:: https://dev.azure.com/wadecarpenter/jobrunner/_apis/build/status/wwade.jobrunner%20(azure%20native)?branchName=master
    :target: https://dev.azure.com/wadecarpenter/jobrunner/_build/latest?definitionId=2&branchName=master
+
+.. |PyPI Release| image:: https://badge.fury.io/py/shell-jobrunner.svg
+   :target: https://badge.fury.io/py/shell-jobrunner


### PR DESCRIPTION
CONTRIBUTING just refers to README.rst now, and I've removed all references to
`tox` since it's no longer in use.