### PR TITLE
main: print key errors to stderr instead of stdout

### DIFF
--- a/jobrunner/main.py
+++ b/jobrunner/main.py
@@ -240,7 +240,7 @@ def main(args=None):
     try:
         impl_main(args=args)
     except NoMatchingJobError as error:
-        sprint("Error:", error)
+        print("Error:", error, file=sys.stderr)
         sys.exit(1)
 
 
@@ -735,7 +735,7 @@ def maybeHandle(options, jobs, handler):
             sys.exit(0)
     except NoMatchingJobError as error:
         jobs.unlock()
-        sprint("Error:", error)
+        print("Error:", error, file=sys.stderr)
         sys.exit(1)
     except ExitCode as exitCode:
         jobs.unlock()


### PR DESCRIPTION
It's never a good idea to put error messages on stdout. Personally I often do things
like this:

    tail -g `job -g foo`

And when there's no key for `foo` it's better to see the error instead of trying to
tail a bunch of nonsense file names based on the error output.