### PR TITLE
main: add --list-keys option to print only the job keys

### DIFF
--- a/jobrunner/db/__init__.py
+++ b/jobrunner/db/__init__.py
@@ -347,8 +347,8 @@ class JobsBase(object):
         return jobList
 
     def listDb(self, db, limit, filterWs=False, filterPane=False, useCp=False,
-               includeReminders=False):
-        # pylint: disable=too-many-arguments
+               includeReminders=False, keysOnly=False):
+        # pylint: disable=too-many-arguments, too-many-branches
         jobList = self.filterJobs(db, limit, filterWs, filterPane, useCp)
         hasDeps = False
         for job in jobList:
@@ -364,6 +364,8 @@ class JobsBase(object):
                 continue
             if self.config.verbose:
                 sprint(job.detail(self.config.verbose[1:]))
+            elif keysOnly:
+                sprint(job.key)
             else:
                 if db is self.active:
                     sprint(job)
@@ -433,14 +435,16 @@ class JobsBase(object):
     def countInactive(self):
         return len(self.inactive.db) - (len(self.inactive.special) - 1)
 
-    def listActive(self, thisWs, pane, useCp, includeReminders):
+    def listActive(self, thisWs, pane, useCp, includeReminders, keysOnly=False):
+        # pylint: disable=too-many-arguments
         self.listDb(
             self.active,
             None,
             filterWs=thisWs,
             filterPane=pane,
             useCp=useCp,
-            includeReminders=includeReminders)
+            includeReminders=includeReminders,
+            keysOnly=keysOnly)
 
     def listInactive(self, thisWs, pane, useCp, limit=5):
         self.listDb(

--- a/jobrunner/main.py
+++ b/jobrunner/main.py
@@ -358,6 +358,10 @@ def addNonExecOptions(op):
         action="append_const",
         const=True,
         help="List active jobs, -ll to include active reminders")
+    op.add_argument(
+        "--list-keys",
+        action="store_true",
+        help="List keys for active jobs, one per line.")
     op.add_argument("--dot", action='store_true',
                     help='Show dependency graph for active jobs')
     op.add_argument("--png", action='store_true',
@@ -431,6 +435,14 @@ def handleNonExecOptions(options, jobs):
         jobs.listActive(thisWs=options.tw, pane=options.tp,
                         useCp=options.since_checkpoint,
                         includeReminders=includeReminders)
+        return True
+    elif options.list_keys:
+        jobs.listActive(
+            thisWs=options.tw,
+            pane=options.tp,
+            useCp=options.since_checkpoint,
+            includeReminders=False,
+            keysOnly=True)
         return True
     elif options.dot or options.png or options.svg:
         dot = jobs.makeDot(


### PR DESCRIPTION
- new feature `--list-keys`
- bug fix: KeyError output to `stderr` instead of `stdout`.