### PR TITLE
lint: prepare for new pylint

### DIFF
--- a/jobrunner/compat.py
+++ b/jobrunner/compat.py
@@ -11,3 +11,10 @@ try:
 except ImportError:
     # Running on pre-3.8 Python; use importlib-metadata package
     import importlib_metadata as metadata
+
+
+def encoding_open(filename, mode='r', encoding='utf-8', **kwargs):
+    try:
+        return open(filename, mode=mode, encoding=encoding, **kwargs)
+    except TypeError:
+        return open(filename, mode=mode, **kwargs)  # pylint: disable=W

--- a/jobrunner/db/__init__.py
+++ b/jobrunner/db/__init__.py
@@ -17,7 +17,7 @@ import six
 from six import text_type
 from six.moves import filter
 
-import jobrunner.utils as utils
+from jobrunner import utils
 
 from ..info import JobInfo, decodeJobInfo, encodeJobInfo
 from ..service import service

--- a/jobrunner/info.py
+++ b/jobrunner/info.py
@@ -11,7 +11,7 @@ import dateutil.tz
 import six
 from six.moves import map, range
 
-import jobrunner.utils as utils
+from jobrunner import utils
 
 from .service import service
 from .utils import (
@@ -380,7 +380,7 @@ class JobInfo(object):
         if self.startTime is None:
             return "Blocked"
         stop = self.stopTime or utcNow()
-        return str(stop - self.startTime).split('.')[0]
+        return str(stop - self.startTime).split('.', 1)[0]
 
     def removeLog(self, verbose):
         if os.access(self.logfile, os.F_OK):

--- a/jobrunner/mail/chat.py
+++ b/jobrunner/mail/chat.py
@@ -35,19 +35,26 @@ to-addr and -c currently operate identically.
 _DEBUG_LOG_FILE_NAME = "chatmail-debug"
 
 
+def _open(filename, mode='r'):
+    try:
+        return open(filename, mode=mode, encoding='utf-8')
+    except TypeError:
+        return open(filename, mode=mode)  # pylint: disable=W
+
+
 class ThreadIdCache(object):
     def __init__(self, cacheDir):
         self._cacheFile = os.path.join(cacheDir, 'chatmail.json')
 
     def _read(self):
         try:
-            with open(self._cacheFile, 'r') as cacheFile:
+            with _open(self._cacheFile, 'r') as cacheFile:
                 return json.load(cacheFile)
         except IOError:
             return {}
 
     def _write(self, data):
-        with open(self._cacheFile, 'w') as cacheFile:
+        with _open(self._cacheFile, 'w') as cacheFile:
             return json.dump(data, cacheFile)
 
     def get(self, key):
@@ -113,7 +120,7 @@ def _getUserAtTokens(users, config):
 def _getMessageBody(opts):
     bodyText = ''
     if opts.inFile:
-        with open(opts.inFile) as inFile:
+        with _open(opts.inFile) as inFile:
             bodyText = inFile.read()
     elif not sys.stdin.isatty():
         bodyText = sys.stdin.read()

--- a/jobrunner/main.py
+++ b/jobrunner/main.py
@@ -18,6 +18,7 @@ import jobrunner.logging
 
 from .argparse import addArgumentParserBaseFlags, baseParsedArgsToArgList
 from .binutils import binDescriptionWithStandardFooter
+from .compat import encoding_open
 from .config import Config
 from .db import NoMatchingJobError
 from .plugins import Plugins
@@ -781,7 +782,7 @@ def runJob(cmd, options, jobs, job, fd, doIsolate):
     LOG.info("execute: %s", job.cmdStr)
     doMsg("execute:", job.cmdStr)
     robotInfo("execute", {"key": job.key}, {"command": job.cmdStr})
-    fpIn = open(options.input, "r")
+    fpIn = encoding_open(options.input, "r")
     rc = -1
     if doIsolate:
         cmd = handleIsolate(cmd)
@@ -798,7 +799,7 @@ def runJob(cmd, options, jobs, job, fd, doIsolate):
     except OSError as err:
         LOG.debug("OSError %s", err, exc_info=1)
         rc = -1 * err.errno
-        sprint(err, file=open(job.logfile, 'a'))
+        sprint(err, file=encoding_open(job.logfile, 'a'))
     except CalledProcessError as err:
         LOG.debug("CalledProcessError %s", err, exc_info=1)
         rc = err.returncode

--- a/jobrunner/test/chatmail_test.py
+++ b/jobrunner/test/chatmail_test.py
@@ -111,9 +111,11 @@ class ChatTest(TestCase):
 
         mocks.configCls().gChatUserHook.return_value = hook
 
-        with patch("jobrunner.mail.chat.open", create=True) as openMock:
+        with patch("jobrunner.mail.chat._open",
+                   create=True, autospec=True) as openMock:
             # Mock inFile from -f option
-            openMock().__enter__().read.return_value = "a bunch of\ntext."
+            openMock("mytext.txt").__enter__(
+            ).read.return_value = "a bunch of\ntext."
             openMock.reset_mock()
             ret = chat.main(['-s', 'My subject', '-c', 'user3', '-c', 'user4',
                              '-a', 'attachfile.txt',

--- a/jobrunner/test/integration/smoke_test.py
+++ b/jobrunner/test/integration/smoke_test.py
@@ -15,6 +15,7 @@ import six
 
 from jobrunner.utils import autoDecode
 
+from ...compat import encoding_open
 from .integration_lib import (
     activeJobs,
     inactiveCount,
@@ -92,9 +93,9 @@ class SmokeTest(TestCase):
             waitFor(lambda: touchFound in activeJobs(), failArg=False)
             time.sleep(1)
             print("write wait file 1")
-            open(waitFile1, 'w').write('')
+            encoding_open(waitFile1, 'w').write('')
             print("write wait file 2")
-            open(waitFile2, 'w').write('')
+            encoding_open(waitFile2, 'w').write('')
             waitFor(noJobs)
             print(run(['job', '-L'], capture=True))
             self.assertEqual(6, inactiveCount())
@@ -203,7 +204,7 @@ class RunExecOptionsTest(TestCase):
                 # --input
                 jobf('--input', inFile.name, '--', 'cat')
             catOutFile = jobf('-g', 'cat').strip()
-            outData = open(catOutFile).read()
+            outData = encoding_open(catOutFile).read()
             assert data == outData
 
     def testWatchWait(self):
@@ -271,7 +272,7 @@ class RunMailTest(TestCase):
     @staticmethod
     def getMailArgs(mailKey):
         lastLog = job('-g', mailKey).splitlines()[0]
-        return json.load(open(lastLog))
+        return json.load(encoding_open(lastLog))
 
     def test(self):
         with testEnv():
@@ -366,7 +367,7 @@ class RunNonExecOptionsTest(TestCase):
             self.assertEqual(file1, firstLog)
             [file2] = job('--index', '0').splitlines()
             for (fileName, value) in ((file1, "first"), (file2, "second")):
-                self.assertIn(value, open(fileName, 'r').read())
+                self.assertIn(value, encoding_open(fileName, 'r').read())
             multiLogFiles = job('-g', firstKey, '-g', secondKey).split()
             self.assertEqual(len(multiLogFiles), 2)
             self.assertNotEqual(multiLogFiles[0], multiLogFiles[1])

--- a/jobrunner/utils.py
+++ b/jobrunner/utils.py
@@ -19,6 +19,8 @@ import dateutil.tz
 from six import text_type
 from six.moves import map, range
 
+from .compat import encoding_open
+
 PRUNE_NUM = 5000
 DATETIME_FMT = "%a %b %e, %Y %X %Z"
 STOP_STOP = -1000
@@ -135,7 +137,7 @@ class FileLock(object):
 
     def lock(self):
         assert self._fp is None
-        self._fp = open(self._filename, 'a')
+        self._fp = encoding_open(self._filename, 'a')
         fcntl.flock(self._fp, fcntl.LOCK_EX)
 
     def unlock(self):

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd "$(dirname $0)"
+cd "$(dirname "$0")" || exit 1
 set -xeuo pipefail
 PY=$(python -c "import sys; print('{}.{}'.format(sys.version_info.major, sys.version_info.minor))")
 python -m pip install --upgrade pip setuptools wheel pipenv
@@ -9,22 +9,25 @@ mirror=()
 if [[ -n "$mirrorUrl" ]]; then
     mirrorUrl=${mirrorUrl/[[:space:]]/}
     echo "mirrorUrl: $mirrorUrl"
-    mirror+="--pypi-mirror=$mirrorUrl"
+    mirror+=(--pypi-mirror="$mirrorUrl")
 fi
-echo "mirror: ${mirror[@]}"
+echo mirror: "${mirror[@]}"
 set -x
-pipenv --python "$PY" "${PIPENV_CMD:-sync}" "${mirror[@]}" --dev --keep-outdated
+
+pipenv=(python -m pipenv)
+
+"${pipenv[@]}" --python "$PY" "${PIPENV_CMD:-sync}" "${mirror[@]}" --dev --keep-outdated
 
 FILES=(setup.py jobrunner)
 if [[ "$PY" =~ 3\. ]]
 then
     FILES+=("test-docker.py")
 fi
-pipenv run isort -c --diff -rc "${FILES[@]}"
-pipenv run autopep8 --exit-code -ra --diff "${FILES[@]}"
-pipenv run pylint -d fixme "${FILES[@]}"
-find jobrunner -type f -name "*.py" -not -name "compat.py" | xargs pipenv run flake8 setup.py
+"${pipenv[@]}" run isort -c --diff -rc "${FILES[@]}"
+"${pipenv[@]}" run autopep8 --exit-code -ra --diff "${FILES[@]}"
+"${pipenv[@]}" run pylint -d fixme "${FILES[@]}"
+find jobrunner -type f -name "*.py" -not -name "compat.py" | xargs "${pipenv[@]}" run flake8 setup.py
 
-pipenv run pip install .
+"${pipenv[@]}" run pip install .
 
-pipenv run pytest -v -l --junitxml=junit/test-results.xml --durations=10 jobrunner/
+"${pipenv[@]}" run pytest -v -l --junitxml=junit/test-results.xml --durations=10 jobrunner/


### PR DESCRIPTION
pylint 2.10.2 adds some new warnings, so update the code to address those. Most
of the warnings were around the `encoding` argument for `open`. In another
instance it now notices using `split(..)[0]` without providing a `maxsplit`
argument of 1, which is a huge help!