### PR TITLE
plugins: add plugin hook for workspaceProject

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -142,7 +142,7 @@ Create new virtualenv and install an editable version of ``jobrunner``:
 .. code:: console
 
     pipenv --three install --dev
-    pipenv run install -e .
+    pipenv run pip install -e .
 
 Autoformat the code and check linters:
 

--- a/jobrunner/info.py
+++ b/jobrunner/info.py
@@ -26,6 +26,7 @@ from .utils import (
     unlocked,
     utcNow,
     workspaceIdentity,
+    workspaceProject,
 )
 
 LOG = getLogger(__name__)
@@ -64,7 +65,7 @@ class JobInfo(object):
         self._user = os.getenv('USER')
         self._env = dict(os.environ)
         self._workspace = workspaceIdentity()
-        self._proj = os.getenv('WP')
+        self._proj = workspaceProject()
         self._rc = None
         self.logfile = None
         self._key = key

--- a/jobrunner/plugins.py
+++ b/jobrunner/plugins.py
@@ -1,8 +1,7 @@
-from __future__ import absolute_import, division, print_function
-
 import importlib
 import pkgutil
 import socket
+from typing import Tuple
 import warnings
 
 import jobrunner.plugin
@@ -46,3 +45,15 @@ class Plugins(object):
                 if ret:
                     return ret
         return socket.gethostname()
+
+    def workspaceProject(self) -> Tuple[str, bool]:
+        """
+        If the current context has a notion of a "project name", return the project
+        name as well as a bool True to indicate that the plugin is authoritative.
+        """
+        for plugin in self.plugins:
+            if hasattr(plugin, 'workspaceProject'):
+                ret, ok = plugin.workspaceProject()
+                if ok:
+                    return ret, ok
+        return "", False

--- a/jobrunner/test/info_test.py
+++ b/jobrunner/test/info_test.py
@@ -33,6 +33,7 @@ def setJobEnv(jobInfo, newEnv):
 def newJob(uidx, cmd, workspaceIdentity="WS"):
     mockPlug = mock.MagicMock(plugins.Plugins)
     mockPlug.workspaceIdentity.return_value = workspaceIdentity
+    mockPlug.workspaceProject.return_value = ("myProject", True)
     utils.MOD_STATE.plugins = mockPlug
     parent = mock.MagicMock(db.JobsBase)
     parent.inactive = mock.MagicMock(db.DatabaseBase)

--- a/jobrunner/utils.py
+++ b/jobrunner/utils.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import collections
 from contextlib import contextmanager
 import datetime
@@ -12,6 +10,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from typing import Optional
 
 import chardet
 import dateutil.tz
@@ -176,6 +175,13 @@ FnDetails = collections.namedtuple('FnDetails', 'filename, lineno, funcname')
 
 def workspaceIdentity():
     return MOD_STATE.plugins.workspaceIdentity()
+
+
+def workspaceProject() -> Optional[str]:
+    proj, ok = MOD_STATE.plugins.workspaceProject()
+    if ok:
+        return proj
+    return os.getenv("WP")
 
 
 def _getAllowed():


### PR DESCRIPTION
It doesn't make sense to look for a magic environment variable WP, but we will
continue to do so if there's no plugin defined. Otherwise, return the value from the
plugin.