### PR TITLE
info: only resolve workspaceIdentity, workspaceProject as needed

### DIFF
--- a/jobrunner/db/__init__.py
+++ b/jobrunner/db/__init__.py
@@ -8,6 +8,7 @@ import os.path
 import sys
 import tempfile
 import time
+from typing import Optional
 from uuid import uuid4
 
 from dateutil import parser
@@ -238,9 +239,27 @@ class JobsBase(object):
         self.plugins = plugins
         self._instanceId = uuid4().hex
         self.displayPending = set()
-        self.active = None
-        self.inactive = None
+        self._active: Optional[DatabaseBase] = None
+        self._inactive: Optional[DatabaseBase] = None
         self._lock = FileLock(self.config.lockFile)
+
+    @property
+    def active(self) -> DatabaseBase:
+        assert self._active
+        return self._active
+
+    @active.setter
+    def active(self, value: DatabaseBase) -> None:
+        self._active = value
+
+    @property
+    def inactive(self) -> DatabaseBase:
+        assert self._inactive
+        return self._inactive
+
+    @inactive.setter
+    def inactive(self, value: DatabaseBase) -> None:
+        self._inactive = value
 
     def setDbCaching(self, enabled):
         pass

--- a/jobrunner/main.py
+++ b/jobrunner/main.py
@@ -140,8 +140,9 @@ def impl_main(args=None):
 
     job: JobInfo
     fd: int
-    job, fd = jobs.new(cmd, doIsolate, autoJob=options.auto_job,
-                       key=options.key, reminder=options.reminder)
+    job, fd = jobs.new(cmd, doIsolate, autoJob=options.auto_job, key=options.key,
+                       reminder=options.reminder)
+    job.resolve()
     job.genPersistKey()
     jobs.active[job.key] = job
 

--- a/jobrunner/utils.py
+++ b/jobrunner/utils.py
@@ -18,6 +18,7 @@ from six import text_type
 from six.moves import map, range
 
 from .compat import encoding_open
+from .plugins import Plugins
 
 PRUNE_NUM = 5000
 DATETIME_FMT = "%a %b %e, %Y %X %Z"
@@ -56,15 +57,15 @@ def sprint(*args, **kwargs):
 
 
 class ModState(object):
-    def __init__(self):
-        self._plugins = None
+    def __init__(self) -> None:
+        self._plugins: Optional[Plugins] = None
 
     @property
-    def plugins(self):
+    def plugins(self) -> Optional[Plugins]:
         return self._plugins
 
     @plugins.setter
-    def plugins(self, plugins):
+    def plugins(self, plugins: Plugins) -> None:
         self._plugins = plugins
 
 
@@ -173,11 +174,13 @@ def pidDebug(*args):
 FnDetails = collections.namedtuple('FnDetails', 'filename, lineno, funcname')
 
 
-def workspaceIdentity():
+def workspaceIdentity() -> Optional[str]:
+    assert MOD_STATE.plugins
     return MOD_STATE.plugins.workspaceIdentity()
 
 
 def workspaceProject() -> Optional[str]:
+    assert MOD_STATE.plugins
     proj, ok = MOD_STATE.plugins.workspaceProject()
     if ok:
         return proj


### PR DESCRIPTION
The plugins' implementation of these methods could be somewhat expensive, so we don't
want to, for example, call workspaceProject() each time a JobInfo is initialized as
part of reading a job entry from the database.

To address this, we call resolve() to resolve the attributes' values in only two
instances:
  1. when the job is created (but not yet started), and
  2. when the job is started.

For the case of (2), `resolve(force=True)` is used so that we override the creation
values in case something has changed in the environment that might affect these values.