### PR TITLE
main: used lockedSection instead of explicit lock/unlock calls

### DIFF
--- a/jobrunner/utils.py
+++ b/jobrunner/utils.py
@@ -126,10 +126,10 @@ class FileLock(object):
 
     def __del__(self):
         if self._fp:
-            sprint(os.getpid(), "WARNING: termination without unlocking")
+            sprint(os.getpid(),
+                   "WARNING: termination without unlocking",
+                   file=sys.stderr)
             self.unlock()
-            self._fp.close()
-            self._fp = None
 
     def isLocked(self):
         return bool(self._fp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,4 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4"]
-build-backend = "setuptools.build_meta"
+requires = ["setuptools>=45", "wheel", "setuptools_scm>=6.2"]
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,17 +16,17 @@ classifiers =
     Operating System :: POSIX
     Operating System :: POSIX :: Linux
     Programming Language :: Python
-    Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Utilities
     Topic :: Terminals
     Topic :: System :: Shells
 
 [options]
-python_requires = >= 2.7
+python_requires = >= 3.7
 setup_requires = setuptools_scm
 install_requires=
     chardet


### PR DESCRIPTION
It's better to use a context manager for locks so that unlock calls are not missed.
Basically we just put a locked section around the implementation of "main", but back
out of it temporarily when we (maybe) fork the child process that runs the job. The
parent then exits (lock not held), while the child process will regain the lock while
it handles the rest of the options, finally releasing it before calling runJob.

In runJob, again, when it terminates, it updates the database and so uses another
lockedSection() call.