### PR TITLE
mail: handle autoDecode failure for job logs with binary data

### DIFF
--- a/jobrunner/main.py
+++ b/jobrunner/main.py
@@ -799,7 +799,13 @@ def extendMailOrNotifyCmdLockRequired(
         safeWrite(tmp, depJob.detail(False))
         safeWrite(tmp, "\n" + SPACER_EACH + "\n")
         assert depJob.logfile
-        lines = autoDecode(check_output(["tail", "-n20", depJob.logfile]))
+        out = check_output(["tail", "-n20", depJob.logfile])
+        try:
+            lines = autoDecode(out)
+        except ValueError as err:
+            LOG.debug("error decoding output from log file %r for %s: %s",
+                      depJob.logfile, depJob, err)
+            lines = f"{out[:50]}\n"
         safeWrite(tmp, lines)
         safeWrite(tmp, SPACER_EACH + "\n")
         safeWrite(tmp, "\n")

--- a/jobrunner/utils.py
+++ b/jobrunner/utils.py
@@ -348,7 +348,7 @@ jobrunner.utils.killProcGroup(pgrp, None)
         try:
             subprocess.check_call(cmd)
         except subprocess.CalledProcessError as error:
-            LOG("cmd %r => error=%s", cmd, error, exc_info=True)
+            LOG.debug("cmd %r => error=%s", cmd, error, exc_info=True)
             return error.output
     return None
 


### PR DESCRIPTION
I ran a command that wrote a tarball into the job log file and so it
couldn't be decoded as utf-8. It subsequently caused autoDecode to
fail with a UnicodeDecodeError.

ValueError is an ancestor of UnicodeDecodeError and would hopefully
cover other decoding errors for other encodings as well.
