### PR TITLE
plugins: support importlib and importlib-metadata

### DIFF
--- a/jobrunner/compat.py
+++ b/jobrunner/compat.py
@@ -2,11 +2,22 @@
 
 # pylint: disable=unused-import
 
+from typing import List
+
 try:
     from importlib import metadata
+    __importlib = True
 except ImportError:
     # Running on pre-3.8 Python; use importlib-metadata package
     import importlib_metadata as metadata
+    __importlib = False
+
+
+def get_plugins(group: str) -> List[metadata.EntryPoint]:
+    eps = metadata.entry_points()
+    if __importlib:
+        return list(eps.get(group, []))
+    return list(eps.select(group=group))
 
 
 def encoding_open(filename, mode='r', encoding='utf-8', **kwargs):

--- a/jobrunner/plugins.py
+++ b/jobrunner/plugins.py
@@ -6,17 +6,15 @@ import warnings
 
 import jobrunner.plugin
 
-from .compat import metadata
+from .compat import get_plugins
 
 
 class Plugins(object):
     def __init__(self):
-        self.plugins = {
-            plug.load() for plug in metadata.entry_points().get(
-                "wwade.jobrunner", [])}
+        self.plugins = {plug.load() for plug in get_plugins("wwade.jobrunner")}
         deprecatedPlugins = {
             importlib.import_module("jobrunner.plugin.{}".format(name))
-            for finder, name, ispkg
+            for _, name, _
             in pkgutil.iter_modules(jobrunner.plugin.__path__)
         }
         if deprecatedPlugins:


### PR DESCRIPTION
The compatibility shims in importlib-metadata were removed, so plugin loading no longer work with python 3.7.