### PR TITLE
ci: include python3.10 in test matrix

### DIFF
--- a/ci/azure/azure-pipelines.yaml
+++ b/ci/azure/azure-pipelines.yaml
@@ -15,9 +15,8 @@ jobs:
           python.version: '3.8'
         Python39:
           python.version: '3.9'
-        # Not yet supported on azure
-        # Python310:
-        #   python.version: '3.10'
+        Python310:
+          python.version: '3.10'
     steps:
       - template: steps.yaml
 


### PR DESCRIPTION
It was previously not supported on azure, but now that it is, turn it on.