### PR TITLE
ci: tweak CI matrix for OS versions

### DIFF
--- a/ci/azure/azure-pipelines.yaml
+++ b/ci/azure/azure-pipelines.yaml
@@ -4,13 +4,11 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/python
 
 jobs:
-  - job: Ubuntu_20_04
+  - job: Ubuntu_22_04
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     strategy:
       matrix:
-        Python38:
-          python.version: '3.8'
         Python39:
           python.version: '3.9'
         Python310:
@@ -20,9 +18,29 @@ jobs:
     steps:
       - template: steps.yaml
 
-  - job: Mac_OS_latest
+  - job: Ubuntu_20_04
     pool:
-      vmImage: macos-latest
+      vmImage: ubuntu-20.04
+    strategy:
+      matrix:
+        Python38:
+          python.version: '3.8'
+    steps:
+      - template: steps.yaml
+
+  - job: MacOS_11
+    pool:
+      vmImage: macos-11
+    strategy:
+      matrix:
+        Python39:
+          python.version: '3.8'
+    steps:
+      - template: steps.yaml
+
+  - job: MacOS_12
+    pool:
+      vmImage: macos-12
     strategy:
       matrix:
         Python39:


### PR DESCRIPTION
Ubuntu LTS 22.04 has been released, so test the newer python versions there. 20.04 comes with python 3.8, so just test with that version on 20.04.

For MacOS, the runner for MacOS 12 has been released, but keep testing 11 and python 3.8 for now.