### PR TITLE
ui: fix --list-inactive to show all inactive jobs

### DIFF
--- a/jobrunner/db/__init__.py
+++ b/jobrunner/db/__init__.py
@@ -455,7 +455,7 @@ class JobsBase(object):
             includeReminders=includeReminders,
             keysOnly=keysOnly)
 
-    def listInactive(self, thisWs, pane, useCp, limit=5):
+    def listInactive(self, thisWs, pane, useCp, limit: Optional[int] = 5):
         self.listDb(
             self.inactive,
             limit,

--- a/jobrunner/main.py
+++ b/jobrunner/main.py
@@ -443,7 +443,11 @@ def handleNonExecOptions(options: argparse.Namespace, jobs: JobsBase):
             sprint("Saved output to", fName)
         return True
     elif options.list_inactive:
-        jobs.listInactive(options.tw, options.tp, options.since_checkpoint)
+        jobs.listInactive(
+            options.tw,
+            options.tp,
+            options.since_checkpoint,
+            limit=None)
         return True
     elif options.count:
         sprint(jobs.countInactive())


### PR DESCRIPTION
The default "limit=5" ended up applying to the "list inactive" call to getDbSorted() ever since 016cafdf57d7fb438b2b04bcea6033de97e10ded (version 2.6.0).

Explicitly pass in limit=None to avoid this problem and continue so show all of the inactive job entries.