### PR TITLE
ci: we don't need to set up versioned lock files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch: {}
   schedule:
     #        ┌───────────── minute (0 - 59)
     #        │  ┌───────────── hour (0 - 23)

--- a/ci/azure/azure-pipelines.yaml
+++ b/ci/azure/azure-pipelines.yaml
@@ -28,16 +28,6 @@ jobs:
     steps:
       - template: steps.yaml
 
-  - job: MacOS_11
-    pool:
-      vmImage: macos-11
-    strategy:
-      matrix:
-        Python39:
-          python.version: '3.8'
-    steps:
-      - template: steps.yaml
-
   - job: MacOS_12
     pool:
       vmImage: macos-12

--- a/ci/azure/steps.yaml
+++ b/ci/azure/steps.yaml
@@ -6,17 +6,7 @@ steps:
   - script: python -m pip install --upgrade pip setuptools wheel pipenv
     displayName: 'Install tools'
 
-
-  - script: |
-      set -x
-      verLock="Pipfile-$(python.version).lock"
-      if [[ -f "$verLock" ]]
-      then
-        ln -svf "$verLock" Pipfile.lock
-      fi
-    displayName: 'Set up Pipfile-$(python.version)'
-
-  - script: pipenv --python '$(python.version)' sync --dev --keep-outdated
+  - script: pipenv --python '$(python.version)' sync --dev
     displayName: Install virtualenv using Pipenv
 
   - script: pipenv run make lint

--- a/test.sh
+++ b/test.sh
@@ -16,7 +16,7 @@ set -x
 
 pipenv=(python -m pipenv)
 
-"${pipenv[@]}" --python "$PY" "${PIPENV_CMD:-sync}" "${mirror[@]}" --dev --keep-outdated
+"${pipenv[@]}" --python "$PY" "${PIPENV_CMD:-sync}" "${mirror[@]}" --dev
 
 FILES=(setup.py jobrunner)
 if [[ "$PY" =~ 3\. ]]


### PR DESCRIPTION
The Pipfile-(version).lock files were removed a while ago.