### PR TITLE
ci: add "all-testing" so that we can require that alone for 'main'

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -47,3 +47,15 @@ jobs:
           path: junit/test-results.xml
           reporter: java-junit
           fail-on-error: true
+
+  all-testing:
+    runs-on: ubuntu-latest
+    needs: [check]
+    if: always()
+    steps:
+      - name: All tests passed
+        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - name: Some tests failed
+        if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1


### PR DESCRIPTION
Instead of having to add branch protection rules for each version in the test matrix, we can just "require" the "all-testing" job.