### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   check:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/wwade/jobrunner/security/code-scanning/2](https://github.com/wwade/jobrunner/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/check.yml` so all jobs inherit minimal access.  
Best fix without changing functionality: set:

- `contents: read` (needed for repository checkout)
- optionally `packages: read` only if package registry reads are required; not clearly required here, so omit for least privilege.

Because neither job needs write capabilities, no job-level overrides are necessary. Place `permissions:` after the `on:` block (or before `jobs:`) so it applies workflow-wide.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
