### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,6 +5,8 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+permissions:
+  contents: read
 jobs:
   check:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Potential fix for [https://github.com/wwade/jobrunner/security/code-scanning/1](https://github.com/wwade/jobrunner/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/check.yml` so all jobs inherit least-privilege token access by default.

Best fix (without changing functionality):
- Insert at workflow root (after `on:` block, before `jobs:`):
  - `permissions:`
  - `contents: read`

Why this is best here:
- Both jobs are CI-only (checkout, setup, install, lint/test, status aggregation) and do not need write scopes.
- Root-level permissions avoids duplication and applies consistently to all current/future jobs unless overridden.
- Keeps behavior unchanged while satisfying CodeQL and least-privilege guidance.

No imports, methods, or extra definitions are needed (YAML workflow only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
