### PR TITLE
ci(deps): configure 10-day minimum release age for Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "minimumReleaseAge": "10 days",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
## Summary
- Add `minimumReleaseAge: "10 days"` to Renovate config to avoid picking up freshly-published versions before they've had time to stabilize

## Test plan
- [ ] Renovate processes the updated config on next scheduled run