### PR TITLE
fix: render printable env values as text in job -vvv

### DIFF
--- a/jobrunner/info.py
+++ b/jobrunner/info.py
@@ -3,7 +3,6 @@ from functools import total_ordering
 from logging import getLogger
 import os
 from shlex import quote
-import string
 from typing import Any, Iterable, List, Optional, Sized
 
 import dateutil.tz
@@ -403,14 +402,12 @@ class JobInfo(object):
                 sprint("Remove logfile %r" % self.logfile)
             os.unlink(self.logfile)
 
-    isprint = set(string.printable) - set(string.whitespace) | {" "}
-
     @staticmethod
     def escEnv(value):
         ret = ""
         LOG.debug("value [%r]", value)
         for char in value:
-            if char in JobInfo.isprint:
+            if char.isprintable():
                 ret += char
             else:
                 ret += "\\x%02x" % ord(char)

--- a/jobrunner/test/info_test.py
+++ b/jobrunner/test/info_test.py
@@ -98,11 +98,19 @@ class TestJobProperties(unittest.TestCase):
     def testEnv(self):
         job = newJob(14, ["ls", "/tmp"])
         job.start(job.parent)
-        env = {"XY": "1", "VAL_WITH_NEWLINE": "first\nsecond"}
+        env = {
+            "XY": "1",
+            "VAL_WITH_NEWLINE": "first\nsecond",
+            "EDITOR": "vim",
+            "UNICODE_VAL": "café",
+        }
         setJobEnv(job, env)
         out = job.getEnvironment()
         self.assertIn("XY=1\n", out)
         self.assertIn("VAL_WITH_NEWLINE=first\\x0asecond", out)
+        # Regression for #42: printable values render as text, not hex escapes.
+        self.assertIn("EDITOR=vim\n", out)
+        self.assertIn("UNICODE_VAL=café\n", out)
         self.assertEqual(job.env("XY"), "1")
         self.assertIsNone(job.env("XYZ"))
         self.assertEqual(job.environ, env)
@@ -158,3 +166,14 @@ class TestInfoHelpers(unittest.TestCase):
         LOG.debug("exp [%r] %s", exp, exp)
         LOG.debug("out [%r] %s", out, out)
         assert exp == out
+
+    def testEscEnvNonAscii(self):
+        # Regression for #42: non-ASCII printable characters must render as
+        # themselves, not as hex escapes (e.g. "café", not "caf\\xe9").
+        for value in ["café", "naïve", "日本語", "Ω", "emoji😀"]:
+            self.assertEqual(value, info.JobInfo.escEnv(value))
+
+    def testEscEnvControlCharsStillEscaped(self):
+        # Non-printable/control characters remain hex-escaped even when mixed
+        # with non-ASCII printable text.
+        self.assertEqual("café\\x00\\x0a", info.JobInfo.escEnv("café\x00\n"))


### PR DESCRIPTION
## Summary

`job -vvv` renders the **Environment** section with values shown as hex
escapes instead of readable text, as reported in #42.

`JobInfo.escEnv` decides whether to print a character or hex-escape it using an
ASCII-only printable set:

```python
isprint = set(string.printable) - set(string.whitespace) | {" "}
...
if char in JobInfo.isprint:
    ret += char
else:
    ret += "\\x%02x" % ord(char)
```

Because `string.printable` only covers ASCII `0x20`–`0x7e`, any **non-ASCII
printable** character in an environment value falls into the `else` branch and
is emitted as a hex escape.

## Reproduction (current `main`)

```console
$ MYVAR='café_déjà' job true
$ job -vvv -s true
...
Environment
	MYVAR=caf\xe9_d\xe9j\xe0
```

The exact all-ASCII example in the issue (`\x76\x69\x6d` for `vim`) was a
Python-2-era `bytes`/`str` artifact and no longer reproduces on Python 3 — but
the underlying cause is the same ASCII-only printability check, which still
mangles any value containing accented Latin, CJK, emoji, etc.

## Fix

Use the Unicode-aware `str.isprintable()` instead of the ASCII-only set:

```python
if char.isprintable():
    ret += char
else:
    ret += "\\x%02x" % ord(char)
```

- For ASCII this is behaviourally identical (`0x20`–`0x7e` printable;
  control chars and non-space whitespace still escaped), so existing behaviour
  and tests are unchanged.
- For non-ASCII it correctly treats printable Unicode as printable, so real
  values render as text.

The now-unused `isprint` class attribute and its `import string` are removed.

## Tests

`jobrunner/test/info_test.py`:

- `testEscEnvNonAscii` — `escEnv("café")`, `"日本語"`, `"Ω"`, emoji round-trip
  unchanged.
- `testEscEnvControlCharsStillEscaped` — control chars remain hex-escaped when
  mixed with non-ASCII text (`escEnv("café\x00\n") == "café\\x00\\x0a"`).
- `TestJobProperties.testEnv` extended to assert `EDITOR=vim` and
  `UNICODE_VAL=café` render as text through `getEnvironment()`.

Existing control-char expectations (`testEscEnv`, `testEscEncUnicode`) are
preserved. `ruff check`, `ruff format --check`, and the unit suite all pass
locally.

Closes #42

---
<sub>Prepared with assistance from the Superhuman open-source contribution plugin.</sub>
